### PR TITLE
Support conversion of AbstractInterval{<:Integer} to AbstractUnitRange

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -27,6 +27,9 @@ function convert{I<:AbstractInterval}(::Type{I}, r::Range)
     T = eltype(I)
     I(convert(T, minimum(r)), convert(T, maximum(r)))
 end
+function convert{R<:AbstractUnitRange,I<:Integer}(::Type{R}, i::AbstractInterval{I})
+    R(minimum(i), maximum(i))
+end
 
 ordered{T}(a::T, b::T) = ifelse(a < b, (a, b), (b, a))
 ordered(a, b) = ordered(promote(a, b)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ using Base.Test
         @test_throws ArgumentError :a .. "b"
         I = 0..3
         @test string(I) == "0..3"
+        @test convert(UnitRange, I) === 0:3
+        @test convert(UnitRange{Int16}, I) === Int16(0):Int16(3)
         J = 3..2
         K = 5..4
         L = 3 ± 2


### PR DESCRIPTION
This is useful in the context of representing array indices as intervals. This comes up in the context of rubber-band selections, where in general you want sub-pixel resolution but in some cases (e.g., selecting a region of an image) you know that integers are all you care about. In such cases, a `ClosedInterval{Int}` is equivalent to a `UnitRange{Int}`, so to me it makes sense to support interconversions. However, I would say that this direction is slightly less-well justified than #12; feel free to chime in if you disagree with this.
