### PR TITLE
Added methods for Base.length.

### DIFF
--- a/src/closed.jl
+++ b/src/closed.jl
@@ -94,6 +94,11 @@ function width{T}(A::ClosedInterval{T})
     max(zero(_width), _width)   # this works when T is a Date
 end
 
+@compat function length{T <: Union{<: Integer, Date}}(A::ClosedInterval{T})
+    _width = A.right - A.left
+    max(zero(_width), _width + oneunit(_width))
+end
+
 function convert{R<:AbstractUnitRange,I<:Integer}(::Type{R}, i::ClosedInterval{I})
     R(minimum(i), maximum(i))
 end
@@ -101,3 +106,4 @@ end
 range{I<:Integer}(i::ClosedInterval{I}) = convert(UnitRange{I}, i)
 
 Base.promote_rule{T1,T2}(::Type{ClosedInterval{T1}}, ::Type{ClosedInterval{T2}}) = ClosedInterval{promote_type(T1, T2)}
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,12 +79,17 @@ using Base.Test
             @test width(ClosedInterval(A, B)) == Base.Dates.Day(59)
             @test width(ClosedInterval(B, A)) == Base.Dates.Day(0)
             @test isempty(ClosedInterval(B, A))
+            @test length(ClosedInterval(A, B)) == Base.Dates.Day(60)
+            @test length(ClosedInterval(B, A)) == Base.Dates.Day(0)
         end
 
         @test width(ClosedInterval(3,7)) ≡ 4
         @test width(ClosedInterval(4.0,8.0)) ≡ 4.0
 
         @test promote(1..2, 1.0..2.0) === (1.0..2.0, 1.0..2.0)
+
+        @test length(I) == 4
+        @test length(J) == 0
     end
 end
 


### PR DESCRIPTION
See discussion at https://github.com/JuliaMath/IntervalSets.jl/issues/21, this should fix the issue.

PR aims to maintain support for v0.5, too, hence the `@compat` for `Union` and the old syntax for type parameters (hope I did it right).