### PR TITLE
Add length

### DIFF
--- a/src/closed.jl
+++ b/src/closed.jl
@@ -94,6 +94,11 @@ function width{T}(A::ClosedInterval{T})
     max(zero(_width), _width)   # this works when T is a Date
 end
 
+@compat function length{T <: Union{<: Integer, Date}}(A::ClosedInterval{T})
+    _width = A.right - A.left
+    max(zero(_width), _width + oneunit(_width))
+end
+
 function convert{R<:AbstractUnitRange,I<:Integer}(::Type{R}, i::ClosedInterval{I})
     R(minimum(i), maximum(i))
 end
@@ -101,3 +106,4 @@ end
 range{I<:Integer}(i::ClosedInterval{I}) = convert(UnitRange{I}, i)
 
 Base.promote_rule{T1,T2}(::Type{ClosedInterval{T1}}, ::Type{ClosedInterval{T2}}) = ClosedInterval{promote_type(T1, T2)}
+

--- a/src/closed.jl
+++ b/src/closed.jl
@@ -94,10 +94,9 @@ function width{T}(A::ClosedInterval{T})
     max(zero(_width), _width)   # this works when T is a Date
 end
 
-@compat function length{T <: Union{<: Integer, Date}}(A::ClosedInterval{T})
-    _width = A.right - A.left
-    max(zero(_width), _width + oneunit(_width))
-end
+length{T <: Integer}(A::ClosedInterval{T}) = max(0, Int(A.right - A.left) + 1)
+
+length(A::ClosedInterval{Date}) = max(0, Dates.days(A.right - A.left) + 1)
 
 function convert{R<:AbstractUnitRange,I<:Integer}(::Type{R}, i::ClosedInterval{I})
     R(minimum(i), maximum(i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,8 +79,8 @@ using Base.Test
             @test width(ClosedInterval(A, B)) == Base.Dates.Day(59)
             @test width(ClosedInterval(B, A)) == Base.Dates.Day(0)
             @test isempty(ClosedInterval(B, A))
-            @test length(ClosedInterval(A, B)) == Base.Dates.Day(60)
-            @test length(ClosedInterval(B, A)) == Base.Dates.Day(0)
+            @test length(ClosedInterval(A, B)) ≡ 60
+            @test length(ClosedInterval(B, A)) ≡ 0
         end
 
         @test width(ClosedInterval(3,7)) ≡ 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,12 +79,17 @@ using Base.Test
             @test width(ClosedInterval(A, B)) == Base.Dates.Day(59)
             @test width(ClosedInterval(B, A)) == Base.Dates.Day(0)
             @test isempty(ClosedInterval(B, A))
+            @test length(ClosedInterval(A, B)) == Base.Dates.Day(60)
+            @test length(ClosedInterval(B, A)) == Base.Dates.Day(0)
         end
 
         @test width(ClosedInterval(3,7)) ≡ 4
         @test width(ClosedInterval(4.0,8.0)) ≡ 4.0
 
         @test promote(1..2, 1.0..2.0) === (1.0..2.0, 1.0..2.0)
+
+        @test length(I) == 4
+        @test length(J) == 0
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,8 @@ using Base.Test
 
         @test length(I) == 4
         @test length(J) == 0
+        # length deliberately not defined for non-integer intervals
+        @test_throws MethodError length(1.2..2.4)
     end
 end
 


### PR DESCRIPTION
Add `Base.length(::ClosedInterval)`, which returns the number of elements in an interval for types which can be mapped to integers (currently all integers and `Date`s). 