### PR TITLE
Add `isless` and make `isequal` consistent with `hash`

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -3,7 +3,7 @@ __precompile__()
 module IntervalSets
 
 using Base: @pure
-import Base: eltype, convert, show, in, length, isempty, isequal, issubset, ==, hash,
+import Base: eltype, convert, show, in, length, isempty, isequal, isless, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, ⊇
 
 using Compat

--- a/src/closed.jl
+++ b/src/closed.jl
@@ -43,7 +43,9 @@ in(a::ClosedInterval, b::ClosedInterval) = (b.left <= a.left) & (a.right <= b.ri
 
 isempty(A::ClosedInterval) = A.left > A.right
 
-isequal(A::ClosedInterval, B::ClosedInterval) = (isequal(A.left, B.left) & isequal(A.right, B.right)) | (isempty(A) & isempty(B))
+isequal(A::ClosedInterval, B::ClosedInterval) = isequal(A.left, B.left) & isequal(A.right, B.right)
+
+isless(A::ClosedInterval, B::ClosedInterval) = isless(A.left, B.left) | (isequal(A.left, B.left) & isless(A.right, B.right))
 
 ==(A::ClosedInterval, B::ClosedInterval) = (A.left == B.left && A.right == B.right) || (isempty(A) && isempty(B))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,11 @@ using Compat.Dates
         @test J == J
         @test L == L
         @test isequal(I, I)
-        @test isequal(J, K)
+        @test !isequal(J, K)
+        @test !isless(I, I)
+        @test isless(I, J)
+        @test !isless(J, I)
+        @test isless(I, 0..4)
 
         @test typeof(M.left) == typeof(M.right) && typeof(M.left) == Float64
         @test typeof(N.left) == typeof(N.right) && typeof(N.left) == Int


### PR DESCRIPTION
The current `isequal` won't work in a `Dict` because it violates the principle that `isequal(a, b)` implies `hash(a, b)`. This is corrected to not special case empty intervals.

I also provide an `isless` function so that intervals can be `sort`ed and so-on.