### PR TITLE
add Base.IteratorSize method

### DIFF
--- a/src/closed.jl
+++ b/src/closed.jl
@@ -103,3 +103,5 @@ end
 range(i::ClosedInterval{I}) where {I<:Integer} = convert(UnitRange{I}, i)
 
 Base.promote_rule(::Type{ClosedInterval{T1}}, ::Type{ClosedInterval{T2}}) where {T1,T2} = ClosedInterval{promote_type(T1, T2)}
+
+Base.IteratorSize(::Type{<:ClosedInterval}) = Base.SizeUnknown()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,15 @@ using Compat.Dates
         @test length(J) == 0
         # length deliberately not defined for non-integer intervals
         @test_throws MethodError length(1.2..2.4)
+
+        # see issue #35 about below test
+        if (v"0.6.99" <= VERSION < v"1.1.0-DEV.123")
+            @test_broken issubset(0.1, 0.0..1.0) == true
+            @test_broken issubset(1.1, 0.0..1.0) == false
+        else
+            @test issubset(0.1, 0.0..1.0) == true
+            @test issubset(1.1, 0.0..1.0) == false
+        end
     end
 end
 


### PR DESCRIPTION
Add a Base.IteratorSize method to resolve an error in calling issubset() method in julia-0.7.