### PR TITLE
Add missing constructor methods

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -222,8 +222,8 @@ function _union(A::TypedEndpointsInterval{L1,R1}, B::TypedEndpointsInterval{L2,R
     Interval{L,R}(left, right)
 end
 
-ClosedInterval{T}(i::UnitRange{I}) where {T,I<:Integer} = ClosedInterval{T}(minimum(i), maximum(i))
-ClosedInterval(i::UnitRange{I}) where {I<:Integer} = ClosedInterval{I}(minimum(i), maximum(i))
+ClosedInterval{T}(i::AbstractUnitRange{I}) where {T,I<:Integer} = ClosedInterval{T}(minimum(i), maximum(i))
+ClosedInterval(i::AbstractUnitRange{I}) where {I<:Integer} = ClosedInterval{I}(minimum(i), maximum(i))
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
         @test @inferred(UnitRange{Int16}(I)) === Int16(0):Int16(3)
         @test @inferred(ClosedInterval(0:3)) === I
         @test @inferred(ClosedInterval{Float64}(0:3)) === 0.0..3.0
+        @test @inferred(ClosedInterval(Base.OneTo(3))) === 1..3
         J = 3..2
         K = 5..4
         L = 3 ± 2


### PR DESCRIPTION
These are needed to get GtkReactive, ProfileView, and ImageView passing tests with the "new" IntervalSets. After this I think we can tag a new version.