### PR TITLE
Support for missing values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 1.0
+julia 0.7

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -6,12 +6,10 @@ using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, ⊇
 
-using Compat.Statistics
-import Compat.Statistics: mean
+using Statistics
+import Statistics: mean
 
-
-using Compat
-using Compat.Dates
+using Dates
 
 export AbstractInterval, Interval, OpenInterval, ClosedInterval,
             ⊇, .., ±, ordered, width, duration, leftendpoint, rightendpoint, endpoints,

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -133,6 +133,11 @@ in(v::Complex, I::TypedEndpointsInterval{:open,:open}) = isreal(v) && in(real(v)
 in(v::Complex, I::TypedEndpointsInterval{:closed,:open}) = isreal(v) && in(real(v), I)
 in(v::Complex, I::TypedEndpointsInterval{:open,:closed}) = isreal(v) && in(real(v), I)
 
+in(::Missing, I::TypedEndpointsInterval{:closed,:closed}) = !isempty(I) && missing
+in(::Missing, I::TypedEndpointsInterval{:open,:open}) = !isempty(I) && missing
+in(::Missing, I::TypedEndpointsInterval{:closed,:open}) = !isempty(I) && missing
+in(::Missing, I::TypedEndpointsInterval{:open,:closed}) = !isempty(I) && missing
+
 in(a::AbstractInterval,                         b::TypedEndpointsInterval{:closed,:closed}) =
     (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
 in(a::TypedEndpointsInterval{:open,:open},      b::TypedEndpointsInterval{:open,:open}) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -600,6 +600,12 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
         @test issubset(0.0, nextfloat(0.0)..1.0) == false
     end
 
+    @testset "missing in" begin
+        @test ismissing(missing in 0..1)
+        @test !(missing in 1..0)
+        @test ismissing(missing in OpenInterval(0, 1))
+    end
+    
     @testset "complex in" begin
         @test 0+im ∉ 0..2
         @test 0+0im ∈ 0..2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using IntervalSets
-using Compat
-using Compat.Test
-using Compat.Dates
-using Compat.Statistics
-import Compat.Statistics: mean
+using Test
+using Dates
+using Statistics
+import Statistics: mean
 
 import IntervalSets: Domain, endpoints, closedendpoints, TypedEndpointsInterval
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -608,6 +608,8 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
         @test ismissing(missing in 0..1)
         @test !(missing in 1..0)
         @test ismissing(missing in OpenInterval(0, 1))
+        @test ismissing(missing in Interval{:closed, :open}(0, 1))
+        @test ismissing(missing in Interval{:open, :closed}(0, 1))
     end
     
     @testset "complex in" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -593,6 +593,11 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
         @test_throws InexactError convert(OpenInterval, I)
     end
 
+    @testset "Missing endpoints" begin
+        @test ismissing(2 in 1..missing)
+        @test_broken ismissing(2 in missing..1)  # would be fixed by julialang#31171
+    end
+
     @testset "issubset" begin
         @test issubset(0.1, 0.0..1.0) == true
         @test issubset(0.0, 0.0..1.0) == true


### PR DESCRIPTION
It's straight-forward, and mirrors the semantics of `missing in []` and `missing in [1,2]`