### PR TITLE
Rename isopen/isclosed to isopenset/isclosedset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -8,8 +8,8 @@ EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "0.7, 1"
 EllipsisNotation = "0.4"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ julia> OpenInterval(0.5..2.5)
 
 julia> Interval{:open,:closed}(1,3)
 1..3 (open–closed)
+
+julia> IntervalSets.isopen(OpenInterval(0.5..2.5))
+true
 ```
+Note that `isopen` for intervals should be qualified with the module name, due
+to the existing `isopen` function in Base that has a different meaning.
 
 The `±` operator may be typed as `\pm<TAB>` (using Julia's LaTeX
 syntax tab-completion).

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ julia> Interval{:open,:closed}(1,3)
 julia> IntervalSets.isopen(OpenInterval(0.5..2.5))
 true
 ```
-Note that `isopen` for intervals should be qualified with the module name, due
-to the existing `isopen` function in Base that has a different meaning.
+Note that `isopen` for intervals is qualified with the module name, because
+`isopen` also exists as a function in Base with a different meaning.
 
 The `±` operator may be typed as `\pm<TAB>` (using Julia's LaTeX
 syntax tab-completion).

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ intervals upon which other packages might build. In particular, we
 for the reason that only one interval package can
 unambiguously define the `..` and `±` operators (see below).
 
-Currently this package defines one concrete type, `ClosedInterval`.
-These define the closed set spanning from `a` to `b`, meaning the
+Currently this package defines one concrete type, `Interval`.
+These define the set spanning from `a` to `b`, meaning the
 interval is defined as the set `{x}` satisfying `a ≤ x ≤ b`. This is
 sometimes written `[a,b]` (mathematics syntax, not Julia syntax) or
 `a..b`.
+
+Optionally, `Interval{L,R}` can represent open and half-open intervals. The type
+parameters `L` and `R` correspond to the left and right endpoint respectively.
+The notation `ClosedInterval` is short for `Interval{:closed,:closed}`, while `OpenInterval` is short for `Interval{:open,:open}`. For example, the interval `Interval{:open,:closed}` corresponds to the set `{x}` satisfying `a < x ≤ b`.
 
 ## Usage
 
@@ -48,12 +52,7 @@ julia> OpenInterval(0.5..2.5)
 
 julia> Interval{:open,:closed}(1,3)
 1..3 (open–closed)
-
-julia> IntervalSets.isopen(OpenInterval(0.5..2.5))
-true
 ```
-Note that `isopen` for intervals is qualified with the module name, because
-`isopen` also exists as a function in Base with a different meaning.
 
 The `±` operator may be typed as `\pm<TAB>` (using Julia's LaTeX
 syntax tab-completion).
@@ -78,6 +77,15 @@ true
 
 julia> (0.25..5) ∪ (3..7.4)    # \cup<TAB>; can also use union()
 0.25..7.4
+
+julia> isclosedset(0.5..2.0)
+true
+
+julia> isopenset(OpenInterval(0.5..2.5))
+true
+
+julia> isleftopen(2..3)
+false
 ```
 
 When computing the union, the result must also be an interval:

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -65,6 +65,9 @@ isclosedset(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
 "Is the interval open?"
 isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
+@deprecate isopen(d) isopenset(d) false
+@deprecate isclosed(d) isclosedset(d)
+
 eltype(::Type{AbstractInterval{T}}) where {T} = T
 @pure eltype(::Type{I}) where {I<:AbstractInterval} = eltype(supertype(I))
 

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -60,6 +60,12 @@ isrightopen(d::AbstractInterval) = !isrightclosed(d)
 
 # Only closed if closed at both endpoints, and similar for open
 isclosed(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
+
+"""
+    IntervalSets.isopen(iv)
+
+Is the interval open?
+"""
 isopen(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
 eltype(::Type{AbstractInterval{T}}) where {T} = T

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -14,7 +14,8 @@ import EllipsisNotation: Ellipsis
 
 export AbstractInterval, Interval, OpenInterval, ClosedInterval,
             ⊇, .., ±, ordered, width, duration, leftendpoint, rightendpoint, endpoints,
-            isclosed, isleftclosed, isrightclosed, isleftopen, isrightopen, closedendpoints,
+            isopenset, isclosedset, isleftclosed, isrightclosed,
+            isleftopen, isrightopen, closedendpoints,
             infimum, supremum
 
 """
@@ -59,14 +60,10 @@ isleftopen(d::AbstractInterval) = !isleftclosed(d)
 isrightopen(d::AbstractInterval) = !isrightclosed(d)
 
 # Only closed if closed at both endpoints, and similar for open
-isclosed(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
+isclosedset(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
 
-"""
-    IntervalSets.isopen(iv)
-
-Is the interval open?
-"""
-isopen(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
+"Is the interval open?"
+isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
 eltype(::Type{AbstractInterval{T}}) where {T} = T
 @pure eltype(::Type{I}) where {I<:AbstractInterval} = eltype(supertype(I))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -49,11 +49,11 @@ end
 convert(::Type{Interval}, i::Interval) = i
 
 function convert(::Type{II}, i::AbstractInterval) where II<:ClosedInterval
-    isclosed(i) ||  throw(InexactError(:convert,II,i))
+    isclosedset(i) ||  throw(InexactError(:convert,II,i))
     II(i)
 end
 function convert(::Type{II}, i::AbstractInterval) where II<:OpenInterval
-    isopen(i) ||  throw(InexactError(:convert,II,i))
+    isopenset(i) ||  throw(InexactError(:convert,II,i))
     II(i)
 end
 function convert(::Type{II}, i::AbstractInterval) where II<:Interval{:open,:closed}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
 @testset "IntervalSets" begin
     if VERSION >= v"1.1"
-        # Julia 1.0 defines getindex(a::GenericArray, i...) in Test, 
+        # Julia 1.0 defines getindex(a::GenericArray, i...) in Test,
         # which could cause an ambiguity with getindex(A::AbstractArray, ::EllipsisNotation.Ellipsis)
         @test isempty(detect_ambiguities(IntervalSets, Base, Core))
     end
@@ -146,17 +146,17 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test @inferred(convert(ClosedInterval{Float64}, I))         ===
                 @inferred(convert(AbstractInterval{Float64}, I))     ===
                 @inferred(convert(Domain{Float64}, I))  ===
-                @inferred(ClosedInterval{Float64}(I))                === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Float64},I)) === 
+                @inferred(ClosedInterval{Float64}(I))                ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Float64},I)) ===
                 0.0..3.0
         @test @inferred(convert(ClosedInterval, I))                  ===
                 @inferred(convert(Interval, I))                      ===
                 @inferred(ClosedInterval(I))                         ===
                 @inferred(Interval(I))                               ===
                 @inferred(convert(AbstractInterval, I))              ===
-                @inferred(convert(Domain, I))           === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed}, I)) === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Int}, I)) === 
+                @inferred(convert(Domain, I))           ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed}, I)) ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Int}, I)) ===
                 @inferred(convert(ClosedInterval{Int}, I)) === I
         @test_throws InexactError convert(OpenInterval, I)
         @test_throws InexactError convert(Interval{:open,:closed}, I)
@@ -175,8 +175,8 @@ struct IncompleteInterval <: AbstractInterval{Int} end
                 @inferred(convert(Interval, J))                      ===
                 @inferred(convert(AbstractInterval, J))              ===
                 @inferred(convert(Domain, J))           ===
-                @inferred(OpenInterval(J))                          === 
-                @inferred(OpenInterval{Int}(J)) === 
+                @inferred(OpenInterval(J))                          ===
+                @inferred(OpenInterval{Int}(J)) ===
                 @inferred(convert(OpenInterval{Int},J)) === OpenInterval(J)
         J = Interval{:open,:closed}(I)
         @test_throws InexactError convert(Interval{:closed,:open}, J)
@@ -244,12 +244,12 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test minimum(d) == infimum(d) == leftendpoint(d)
             @test maximum(d) == supremum(d) == rightendpoint(d)
 
-            @test IntervalSets.isclosed(d)
-            @test !IntervalSets.isopen(d)
+            @test IntervalSets.isclosedset(d)
+            @test !IntervalSets.isopenset(d)
             @test IntervalSets.isleftclosed(d)
             @test !IntervalSets.isleftopen(d)
             @test !IntervalSets.isrightopen(d)
-            @test IntervalSets.isrightclosed(d)            
+            @test IntervalSets.isrightclosed(d)
 
             @test convert(AbstractInterval, d) ≡ d
             @test convert(AbstractInterval{T}, d) ≡ d
@@ -257,14 +257,14 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test convert(IntervalSets.Domain{T}, d) ≡ d
 
             d = OpenInterval(zero(T) .. one(T))
-            @test IntervalSets.isopen(d)
-            @test !IntervalSets.isclosed(d)
-            @test IntervalSets.isopen(d)
-            @test !IntervalSets.isclosed(d)
+            @test IntervalSets.isopenset(d)
+            @test !IntervalSets.isclosedset(d)
+            @test IntervalSets.isopenset(d)
+            @test !IntervalSets.isclosedset(d)
             @test !IntervalSets.isleftclosed(d)
             @test IntervalSets.isleftopen(d)
             @test IntervalSets.isrightopen(d)
-            @test !IntervalSets.isrightclosed(d)            
+            @test !IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∉ d
             @test BigFloat(leftendpoint(d)) ∉ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -285,12 +285,12 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test isempty(OpenInterval(1,1))
 
             d = Interval{:open,:closed}(zero(T) .. one(T))
-            @test !IntervalSets.isopen(d)
-            @test !IntervalSets.isclosed(d)
+            @test !IntervalSets.isopenset(d)
+            @test !IntervalSets.isclosedset(d)
             @test !IntervalSets.isleftclosed(d)
             @test IntervalSets.isleftopen(d)
             @test !IntervalSets.isrightopen(d)
-            @test IntervalSets.isrightclosed(d)       
+            @test IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∉ d
             @test BigFloat(leftendpoint(d)) ∉ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -308,12 +308,12 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test_throws ArgumentError minimum(d)
 
             d = Interval{:closed,:open}(zero(T) .. one(T))
-            @test !IntervalSets.isopen(d)
-            @test !IntervalSets.isclosed(d)
+            @test !IntervalSets.isopenset(d)
+            @test !IntervalSets.isclosedset(d)
             @test IntervalSets.isleftclosed(d)
             @test !IntervalSets.isleftopen(d)
             @test IntervalSets.isrightopen(d)
-            @test !IntervalSets.isrightclosed(d)            
+            @test !IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∈ d
             @test BigFloat(leftendpoint(d)) ∈ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -651,7 +651,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test ismissing(missing in Interval{:closed, :open}(0, 1))
         @test ismissing(missing in Interval{:open, :closed}(0, 1))
     end
-    
+
     @testset "complex in" begin
         @test 0+im ∉ 0..2
         @test 0+0im ∈ 0..2


### PR DESCRIPTION
Following the discussion in #59, this pull request adds documentation for the `isopen` function defined by IntervalSets. This function is separate from the existing `isopen` function in Base and it did not yet have documentation.

The pull request adds documentation to the function itself, as well as a brief note to README.md in the section on open intervals. It is an alternative to importing and extending `isopen` from Base.