### PR TITLE
Fix issubset function for open interval #61

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -131,22 +131,15 @@ in(::Missing, I::TypedEndpointsInterval{:open,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:closed,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:open,:closed}) = !isempty(I) && missing
 
-in(a::AbstractInterval,                         b::TypedEndpointsInterval{:closed,:closed}) =
-    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-in(a::TypedEndpointsInterval{:open,:open},      b::TypedEndpointsInterval{:open,:open}) =
-    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-in(a::TypedEndpointsInterval{:closed,:open},    b::TypedEndpointsInterval{:open,:open}) =
-    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-in(a::TypedEndpointsInterval{:open,:closed},    b::TypedEndpointsInterval{:open,:open}) =
-    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-in(a::TypedEndpointsInterval{:closed,:closed},  b::TypedEndpointsInterval{:open,:open}) =
-    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-in(a::TypedEndpointsInterval{:closed},          b::TypedEndpointsInterval{:open,:closed}) =
-    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-in(a::TypedEndpointsInterval{:open},            b::TypedEndpointsInterval{:open,:closed}) =
-    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-in(a::TypedEndpointsInterval{L,:closed}, b::TypedEndpointsInterval{:closed,:open}) where L = (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-in(a::TypedEndpointsInterval{L,:open}, b::TypedEndpointsInterval{:closed,:open}) where L = (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::AbstractInterval,                         b::TypedEndpointsInterval{:closed,:closed}) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:open,:open},      b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:closed,:open},    b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:open,:closed},    b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:closed,:closed},  b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:closed},          b::TypedEndpointsInterval{:open,:closed}  ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{:open},            b::TypedEndpointsInterval{:open,:closed}  ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{L,:closed}, b::TypedEndpointsInterval{:closed,:open}) where L  (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+@deprecate in(a::TypedEndpointsInterval{L,:open},   b::TypedEndpointsInterval{:closed,:open}) where L  (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
 
 isempty(A::TypedEndpointsInterval{:closed,:closed}) = leftendpoint(A) > rightendpoint(A)
 isempty(A::TypedEndpointsInterval) = leftendpoint(A) ≥ rightendpoint(A)
@@ -160,7 +153,7 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) || (Bl ≤ Al && Ar ≤ Br)
+    return isempty(A) || ( Bl ≤ Al && Ar ≤ Br )
 end
 function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
     Al, Ar = endpoints(A)

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -153,7 +153,7 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl ≤ Al && Ar ≤ Br )
+    return isempty(A) | ( Bl ≤ Al && Ar ≤ Br )
 end
 function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
     Al, Ar = endpoints(A)

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -93,32 +93,6 @@ end
 
 mean(d::AbstractInterval) = (leftendpoint(d) + rightendpoint(d))/2
 
-function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
-    Al, Ar = endpoints(A)
-    Bl, Br = endpoints(B)
-    return isempty(A) || (Bl ≤ Al && Ar ≤ Br)
-end
-function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
-    Al, Ar = endpoints(A)
-    Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl < Al && Ar ≤ Br )
-end
-function issubset(A::TypedEndpointsInterval{L1,:closed} where L1, B::TypedEndpointsInterval{L2,:open} where L2)
-    Al, Ar = endpoints(A)
-    Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl ≤ Al && Ar < Br )
-end
-function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsInterval{:open,:open})
-    Al, Ar = endpoints(A)
-    Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl < Al && Ar < Br )
-end
-
-⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)
-if VERSION < v"1.1.0-DEV.123"
-    issubset(x, B::AbstractInterval) = issubset(convert(AbstractInterval, x), B)
-end
-
 """
     w = width(iv)
 
@@ -182,6 +156,32 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 
 ==(A::TypedEndpointsInterval{L,R}, B::TypedEndpointsInterval{L,R}) where {L,R} = (leftendpoint(A) == leftendpoint(B) && rightendpoint(A) == rightendpoint(B)) || (isempty(A) && isempty(B))
 ==(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) && isempty(B)
+
+function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || (Bl ≤ Al && Ar ≤ Br)
+end
+function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl < Al && Ar ≤ Br )
+end
+function issubset(A::TypedEndpointsInterval{L1,:closed} where L1, B::TypedEndpointsInterval{L2,:open} where L2)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl ≤ Al && Ar < Br )
+end
+function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsInterval{:open,:open})
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl < Al && Ar < Br )
+end
+
+⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)
+if VERSION < v"1.1.0-DEV.123"
+    issubset(x, B::AbstractInterval) = issubset(convert(AbstractInterval, x), B)
+end
 
 const _interval_hash = UInt == UInt64 ? 0x1588c274e0a33ad4 : 0x1e3f7252
 

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -93,7 +93,27 @@ end
 
 mean(d::AbstractInterval) = (leftendpoint(d) + rightendpoint(d))/2
 
-issubset(A::AbstractInterval, B::AbstractInterval) = ((leftendpoint(A) in B) && (rightendpoint(A) in B)) || isempty(A)
+function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || (Bl ≤ Al && Ar ≤ Br)
+end
+function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl < Al && Ar ≤ Br )
+end
+function issubset(A::TypedEndpointsInterval{L1,:closed} where L1, B::TypedEndpointsInterval{L2,:open} where L2)
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl ≤ Al && Ar < Br )
+end
+function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsInterval{:open,:open})
+    Al, Ar = endpoints(A)
+    Bl, Br = endpoints(B)
+    return isempty(A) || ( Bl < Al && Ar < Br )
+end
+
 ⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)
 if VERSION < v"1.1.0-DEV.123"
     issubset(x, B::AbstractInterval) = issubset(convert(AbstractInterval, x), B)

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -131,8 +131,28 @@ in(::Missing, I::TypedEndpointsInterval{:open,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:closed,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:open,:closed}) = !isempty(I) && missing
 
-function in(a::AbstractInterval, b::AbstractInterval)
-    Base.depwarn("`in(a, b)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+# The code below can be defined as
+# ```
+# function in(a::AbstractInterval, b::AbstractInterval)
+#     Base.depwarn("`in(a::AbstractInterval, b::AbstractInterval)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+#     return in_deprecation(a, b)
+# end
+# ```
+# but that makes ambiguity definition.
+function in(a::AbstractInterval, b::TypedEndpointsInterval{:closed,:closed})
+    Base.depwarn("`in(a::AbstractInterval, b::AbstractInterval)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+    return in_deprecation(a, b)
+end
+function in(a::AbstractInterval, b::TypedEndpointsInterval{:open,:open})
+    Base.depwarn("`in(a::AbstractInterval, b::AbstractInterval)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+    return in_deprecation(a, b)
+end
+function in(a::AbstractInterval, b::TypedEndpointsInterval{:closed,:open})
+    Base.depwarn("`in(a::AbstractInterval, b::AbstractInterval)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+    return in_deprecation(a, b)
+end
+function in(a::AbstractInterval, b::TypedEndpointsInterval{:open,:closed})
+    Base.depwarn("`in(a::AbstractInterval, b::AbstractInterval)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
     return in_deprecation(a, b)
 end
 
@@ -167,22 +187,22 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) | ( Bl ≤ Al & Ar ≤ Br )
+    return isempty(A) | ( (Bl ≤ Al) & (Ar ≤ Br) )
 end
 function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) | ( Bl < Al & Ar ≤ Br )
+    return isempty(A) | ( (Bl < Al) & (Ar ≤ Br) )
 end
 function issubset(A::TypedEndpointsInterval{L1,:closed} where L1, B::TypedEndpointsInterval{L2,:open} where L2)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) | ( Bl ≤ Al & Ar < Br )
+    return isempty(A) | ( (Bl ≤ Al) & (Ar < Br) )
 end
 function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsInterval{:open,:open})
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) | ( Bl < Al & Ar < Br )
+    return isempty(A) | ( (Bl < Al) & (Ar < Br) )
 end
 
 ⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -131,15 +131,29 @@ in(::Missing, I::TypedEndpointsInterval{:open,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:closed,:open}) = !isempty(I) && missing
 in(::Missing, I::TypedEndpointsInterval{:open,:closed}) = !isempty(I) && missing
 
-@deprecate in(a::AbstractInterval,                         b::TypedEndpointsInterval{:closed,:closed}) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:open,:open},      b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:closed,:open},    b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:open,:closed},    b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:closed,:closed},  b::TypedEndpointsInterval{:open,:open}    ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:closed},          b::TypedEndpointsInterval{:open,:closed}  ) (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{:open},            b::TypedEndpointsInterval{:open,:closed}  ) (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{L,:closed}, b::TypedEndpointsInterval{:closed,:open}) where L  (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
-@deprecate in(a::TypedEndpointsInterval{L,:open},   b::TypedEndpointsInterval{:closed,:open}) where L  (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+function in(a::AbstractInterval, b::AbstractInterval)
+    Base.depwarn("`in(a, b)` (equivalently, `a ∈ b`) is deprecated in favor of `issubset(a, b)` (equivalently, `a ⊆ b`). Note that the behavior for empty intervals is also changing.", :in)
+    return in_deprecation(a, b)
+end
+
+in_deprecation(a::AbstractInterval,                         b::TypedEndpointsInterval{:closed,:closed}) =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:open,:open},      b::TypedEndpointsInterval{:open,:open}    ) =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:closed,:open},    b::TypedEndpointsInterval{:open,:open}    ) =
+    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:open,:closed},    b::TypedEndpointsInterval{:open,:open}    ) =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:closed,:closed},  b::TypedEndpointsInterval{:open,:open}    ) =
+    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:closed},          b::TypedEndpointsInterval{:open,:closed}  ) =
+    (leftendpoint(a) > leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{:open},            b::TypedEndpointsInterval{:open,:closed}  ) =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{L,:closed}, b::TypedEndpointsInterval{:closed,:open}) where L  =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) < rightendpoint(b))
+in_deprecation(a::TypedEndpointsInterval{L,:open},   b::TypedEndpointsInterval{:closed,:open}) where L  =
+    (leftendpoint(a) ≥ leftendpoint(b)) & (rightendpoint(a) ≤ rightendpoint(b))
 
 isempty(A::TypedEndpointsInterval{:closed,:closed}) = leftendpoint(A) > rightendpoint(A)
 isempty(A::TypedEndpointsInterval) = leftendpoint(A) ≥ rightendpoint(A)
@@ -153,22 +167,22 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 function issubset(A::TypedEndpointsInterval, B::TypedEndpointsInterval)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) | ( Bl ≤ Al && Ar ≤ Br )
+    return isempty(A) | ( Bl ≤ Al & Ar ≤ Br )
 end
 function issubset(A::TypedEndpointsInterval{:closed,R1} where R1, B::TypedEndpointsInterval{:open,R2} where R2)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl < Al && Ar ≤ Br )
+    return isempty(A) | ( Bl < Al & Ar ≤ Br )
 end
 function issubset(A::TypedEndpointsInterval{L1,:closed} where L1, B::TypedEndpointsInterval{L2,:open} where L2)
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl ≤ Al && Ar < Br )
+    return isempty(A) | ( Bl ≤ Al & Ar < Br )
 end
 function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsInterval{:open,:open})
     Al, Ar = endpoints(A)
     Bl, Br = endpoints(B)
-    return isempty(A) || ( Bl < Al && Ar < Br )
+    return isempty(A) | ( Bl < Al & Ar < Br )
 end
 
 ⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test extrema(I) === (0, 3)
 
         @test 2 in I
-        @test 1..2 in 0.5..2.5
+        @test issubset(1..2, 0.5..2.5)
 
         @test @inferred(I ∪ L) == ClosedInterval(0, 5)
         @test @inferred(I ∩ L) == ClosedInterval(1, 3)
@@ -343,36 +343,36 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         end
     end
 
-    @testset "In" begin
+    @testset "Issubset" begin
         I = 0..3
         J = 1..2
-        @test J ∈ I
-        @test I ∉ J
-        @test OpenInterval(J) ∈ I
-        @test OpenInterval(I) ∉ J
-        @test J ∈ OpenInterval(I)
-        @test I ∉ OpenInterval(J)
-        @test OpenInterval(J) ∈ OpenInterval(I)
-        @test OpenInterval(I) ∉ OpenInterval(J)
-        @test Interval{:closed,:open}(J) ∈ OpenInterval(I)
-        @test Interval{:open,:closed}(J) ∈ OpenInterval(I)
-        @test Interval{:open,:closed}(J) ∈ Interval{:open,:closed}(I)
-        @test OpenInterval(I) ∉ OpenInterval(J)
+        @test J ⊆ I
+        @test I ⊈ J
+        @test OpenInterval(J) ⊆ I
+        @test OpenInterval(I) ⊈ J
+        @test J ⊆ OpenInterval(I)
+        @test I ⊈ OpenInterval(J)
+        @test OpenInterval(J) ⊆ OpenInterval(I)
+        @test OpenInterval(I) ⊈ OpenInterval(J)
+        @test Interval{:closed,:open}(J) ⊆ OpenInterval(I)
+        @test Interval{:open,:closed}(J) ⊆ OpenInterval(I)
+        @test Interval{:open,:closed}(J) ⊆ Interval{:open,:closed}(I)
+        @test OpenInterval(I) ⊈ OpenInterval(J)
 
-        @test Interval{:closed,:open}(J) ∈ I
-        @test I ∉ Interval{:closed,:open}(J)
+        @test Interval{:closed,:open}(J) ⊆ I
+        @test I ⊈ Interval{:closed,:open}(J)
 
 
-        @test I ∈ I
-        @test OpenInterval(I) ∈ I
-        @test Interval{:open,:closed}(I) ∈ I
-        @test Interval{:closed,:open}(I) ∈ I
-        @test I ∉ OpenInterval(I)
-        @test I ∉ Interval{:open,:closed}(I)
-        @test I ∉ Interval{:closed,:open}(I)
+        @test I ⊆ I
+        @test OpenInterval(I) ⊆ I
+        @test Interval{:open,:closed}(I) ⊆ I
+        @test Interval{:closed,:open}(I) ⊆ I
+        @test I ⊈ OpenInterval(I)
+        @test I ⊈ Interval{:open,:closed}(I)
+        @test I ⊈ Interval{:closed,:open}(I)
 
-        @test Interval{:closed,:open}(I) ∈ Interval{:closed,:open}(I)
-        @test Interval{:open,:closed}(I) ∉ Interval{:closed,:open}(I)
+        @test Interval{:closed,:open}(I) ⊆ Interval{:closed,:open}(I)
+        @test Interval{:open,:closed}(I) ⊈ Interval{:closed,:open}(I)
 
         @test !isequal(I, OpenInterval(I))
         @test !(I == OpenInterval(I))
@@ -646,10 +646,9 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
     @testset "issubset" begin
         @test issubset(Interval{:closed,:closed}(1,2), Interval{:closed,:closed}(1,2)) == true
-        @test issubset(Interval{:open,  :open  }(1,2), Interval{:open  ,:open  }(1,2)) == true
+        @test issubset(Interval{:closed,:closed}(1,2), Interval{:open  ,:open  }(1,2)) == false
         @test issubset(Interval{:closed,:open  }(1,2), Interval{:open  ,:open  }(1,2)) == false
-        @test issubset(Interval{:closed,:open  }(1,2), Interval{:closed,:open  }(1,2)) == true
-        @test issubset(Interval{:closed,:open  }(1,2), Interval{:closed,:open  }(1,2)) == true
+        @test issubset(Interval{:open  ,:closed}(1,2), Interval{:open  ,:open  }(1,2)) == false
         @test issubset(Interval{:closed,:closed}(1,2), Interval{:closed,:closed}(1,prevfloat(2.0))) == false
         @test issubset(Interval{:closed,:open  }(1,2), Interval{:open  ,:open  }(prevfloat(1.0),2)) == true
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
 @testset "IntervalSets" begin
     if VERSION >= v"1.1"
-        # Julia 1.0 defines getindex(a::GenericArray, i...) in Test, 
+        # Julia 1.0 defines getindex(a::GenericArray, i...) in Test,
         # which could cause an ambiguity with getindex(A::AbstractArray, ::EllipsisNotation.Ellipsis)
         @test isempty(detect_ambiguities(IntervalSets, Base, Core))
     end
@@ -146,17 +146,17 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test @inferred(convert(ClosedInterval{Float64}, I))         ===
                 @inferred(convert(AbstractInterval{Float64}, I))     ===
                 @inferred(convert(Domain{Float64}, I))  ===
-                @inferred(ClosedInterval{Float64}(I))                === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Float64},I)) === 
+                @inferred(ClosedInterval{Float64}(I))                ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Float64},I)) ===
                 0.0..3.0
         @test @inferred(convert(ClosedInterval, I))                  ===
                 @inferred(convert(Interval, I))                      ===
                 @inferred(ClosedInterval(I))                         ===
                 @inferred(Interval(I))                               ===
                 @inferred(convert(AbstractInterval, I))              ===
-                @inferred(convert(Domain, I))           === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed}, I)) === 
-                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Int}, I)) === 
+                @inferred(convert(Domain, I))           ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed}, I)) ===
+                @inferred(convert(TypedEndpointsInterval{:closed,:closed,Int}, I)) ===
                 @inferred(convert(ClosedInterval{Int}, I)) === I
         @test_throws InexactError convert(OpenInterval, I)
         @test_throws InexactError convert(Interval{:open,:closed}, I)
@@ -175,8 +175,8 @@ struct IncompleteInterval <: AbstractInterval{Int} end
                 @inferred(convert(Interval, J))                      ===
                 @inferred(convert(AbstractInterval, J))              ===
                 @inferred(convert(Domain, J))           ===
-                @inferred(OpenInterval(J))                          === 
-                @inferred(OpenInterval{Int}(J)) === 
+                @inferred(OpenInterval(J))                          ===
+                @inferred(OpenInterval{Int}(J)) ===
                 @inferred(convert(OpenInterval{Int},J)) === OpenInterval(J)
         J = Interval{:open,:closed}(I)
         @test_throws InexactError convert(Interval{:closed,:open}, J)
@@ -249,7 +249,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test IntervalSets.isleftclosed(d)
             @test !IntervalSets.isleftopen(d)
             @test !IntervalSets.isrightopen(d)
-            @test IntervalSets.isrightclosed(d)            
+            @test IntervalSets.isrightclosed(d)
 
             @test convert(AbstractInterval, d) ≡ d
             @test convert(AbstractInterval{T}, d) ≡ d
@@ -264,7 +264,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test !IntervalSets.isleftclosed(d)
             @test IntervalSets.isleftopen(d)
             @test IntervalSets.isrightopen(d)
-            @test !IntervalSets.isrightclosed(d)            
+            @test !IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∉ d
             @test BigFloat(leftendpoint(d)) ∉ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -290,7 +290,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test !IntervalSets.isleftclosed(d)
             @test IntervalSets.isleftopen(d)
             @test !IntervalSets.isrightopen(d)
-            @test IntervalSets.isrightclosed(d)       
+            @test IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∉ d
             @test BigFloat(leftendpoint(d)) ∉ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -313,7 +313,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
             @test IntervalSets.isleftclosed(d)
             @test !IntervalSets.isleftopen(d)
             @test IntervalSets.isrightopen(d)
-            @test !IntervalSets.isrightclosed(d)            
+            @test !IntervalSets.isrightclosed(d)
             @test leftendpoint(d) ∈ d
             @test BigFloat(leftendpoint(d)) ∈ d
             @test nextfloat(leftendpoint(d)) ∈ d
@@ -637,11 +637,21 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test_broken ismissing(2 in missing..1)  # would be fixed by julialang#31171
     end
 
+    @testset "in" begin
+        @test in(0.1, 0.0..1.0) == true
+        @test in(0.0, 0.0..1.0) == true
+        @test in(1.1, 0.0..1.0) == false
+        @test in(0.0, nextfloat(0.0)..1.0) == false
+    end
+
     @testset "issubset" begin
-        @test issubset(0.1, 0.0..1.0) == true
-        @test issubset(0.0, 0.0..1.0) == true
-        @test issubset(1.1, 0.0..1.0) == false
-        @test issubset(0.0, nextfloat(0.0)..1.0) == false
+        @test issubset(Interval{:closed,:closed}(1,2), Interval{:closed,:closed}(1,2)) == true
+        @test issubset(Interval{:open,  :open  }(1,2), Interval{:open  ,:open  }(1,2)) == true
+        @test issubset(Interval{:closed,:open  }(1,2), Interval{:open  ,:open  }(1,2)) == false
+        @test issubset(Interval{:closed,:open  }(1,2), Interval{:closed,:open  }(1,2)) == true
+        @test issubset(Interval{:closed,:open  }(1,2), Interval{:closed,:open  }(1,2)) == true
+        @test issubset(Interval{:closed,:closed}(1,2), Interval{:closed,:closed}(1,prevfloat(2.0))) == false
+        @test issubset(Interval{:closed,:open  }(1,2), Interval{:open  ,:open  }(prevfloat(1.0),2)) == true
     end
 
     @testset "missing in" begin
@@ -651,7 +661,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test ismissing(missing in Interval{:closed, :open}(0, 1))
         @test ismissing(missing in Interval{:open, :closed}(0, 1))
     end
-    
+
     @testset "complex in" begin
         @test 0+im ∉ 0..2
         @test 0+0im ∈ 0..2


### PR DESCRIPTION
This change provides:
```
Interval{:closed,:closed}(1,2) ⊆ Interval{:closed,:closed}(1,2) # true  (previoussly, it returns true )
Interval{:open,  :open  }(1,2) ⊆ Interval{:open  ,:open  }(1,2) # true  (previoussly, it returns false)
Interval{:closed,:open  }(1,2) ⊆ Interval{:open  ,:open  }(1,2) # false (previoussly, it returns false)
Interval{:closed,:open  }(1,2) ⊆ Interval{:closed,:open  }(1,2) # true  (previoussly, it returns false)
```