### PR TITLE
Fix [compat] table for EllipsisNotation.jl v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-EllipsisNotation = "0.4"
+EllipsisNotation = "0.4, 1"
 julia = "0.7, 1"
 
 [extras]


### PR DESCRIPTION
Since EllipsisNotation.jl released [version 1.0.0](https://github.com/ChrisRackauckas/EllipsisNotation.jl/releases/tag/v1.0.0), I updated `[compat]` table in `Project.toml`.