### PR TITLE
Range interface for Intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -257,7 +257,7 @@ range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRan
 Constructs a range of a specified step or length.
 """
 range(i::TypedEndpointsInterval{:closed,:closed}; step=nothing, length=nothing) =
-    range(endpoints(i)...; step=step, length=length)
+    range(leftendpoint(i); stop=rightendpoint(i), step=step, length=length)
 range(i::TypedEndpointsInterval{:closed,:closed}, len::Integer) = range(i; length=len)
 
 """

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -257,7 +257,7 @@ range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRan
 Constructs a range of a specified step or length.
 """
 range(i::TypedEndpointsInterval{:closed,:closed}; step=nothing, length=nothing) =
-    range(endpoints(i)...; step, length)
+    range(endpoints(i)...; step=step, length=length)
 range(i::TypedEndpointsInterval{:closed,:closed}, len::Integer) = range(i; length=len)
 
 """
@@ -267,7 +267,7 @@ range(i::TypedEndpointsInterval{:closed,:closed}, len::Integer) = range(i; lengt
 Constructs a range of a specified length with `step=width(i)/length`.
 """
 range(i::TypedEndpointsInterval{:closed,:open}; length::Integer) =
-    range(leftendpoint(i); step=width(i)/length, length)
+    range(leftendpoint(i); step=width(i)/length, length=length)
 range(i::TypedEndpointsInterval{:closed,:open}, len::Integer) = range(i; length=len)
 
 

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -251,6 +251,27 @@ UnitRange(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = Uni
 range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
 
 """
+    range(i::ClosedInterval; step, length)
+    range(i::ClosedInterval, len::Integer)
+
+Constructs a range of a specified step or length.
+"""
+range(i::TypedEndpointsInterval{:closed,:closed}; step=nothing, length=nothing) =
+    range(endpoints(i)...; step, length)
+range(i::TypedEndpointsInterval{:closed,:closed}, len::Integer) = range(i; length=len)
+
+"""
+    range(i::Interval{:closed,:open}; length)
+    range(i::Interval{:closed,:open}, len::Integer)
+
+Constructs a range of a specified length with `step=width(i)/length`.
+"""
+range(i::TypedEndpointsInterval{:closed,:open}; length::Integer) =
+    range(leftendpoint(i); step=width(i)/length, length)
+range(i::TypedEndpointsInterval{:closed,:open}, len::Integer) = range(i; length=len)
+
+
+"""
    duration(iv)
 
 calculates the the total number of integers or dates of an integer or date

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -697,6 +697,14 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test Base.Slice(1..5) == Base.Slice{UnitRange{Int}}(1..5) == Base.Slice(1:5)
     end
 
+    @testset "range" begin
+        @test range(0..1, 10) == range(0, 1; length=10)
+        @test range(0..1; length=10) == range(0, 1; length=10)
+        @test range(0..1; step=1/10) == range(0, 1; step=1/10)
+        @test range(Interval{:closed,:open}(0..1), 10) == range(0; step=1/10, length=10)
+        @test range(Interval{:closed,:open}(0..1); length=10) == range(0; step=1/10, length=10)
+    end
+
     @testset "IteratorSize" begin
         @test Base.IteratorSize(ClosedInterval) == Base.SizeUnknown()
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -698,9 +698,9 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     end
 
     @testset "range" begin
-        @test range(0..1, 10) == range(0, 1; length=10)
-        @test range(0..1; length=10) == range(0, 1; length=10)
-        @test range(0..1; step=1/10) == range(0, 1; step=1/10)
+        @test range(0..1, 10) == range(0; stop=1, length=10)
+        @test range(0..1; length=10) == range(0; stop=1, length=10)
+        @test range(0..1; step=1/10) == range(0; stop=1, step=1/10)
         @test range(Interval{:closed,:open}(0..1), 10) == range(0; step=1/10, length=10)
         @test range(Interval{:closed,:open}(0..1); length=10) == range(0; step=1/10, length=10)
     end


### PR DESCRIPTION
This adds the possibility to create a `range` from a `ClosedInterval` or half open interval `Interval{:closed,:open}`.

For a closed interval `[a,b]` this constructs a `range` of length `length` or step `step` equivalent to `range(a, b; step, length)`.

For a half open interval `[a,b)` we do not want `b` to be included, but the range should have the specified `length`, so the step should be `(b-a)/length`.

So for closed intervals the meaning is to create a range starting from `a` and at most ending at `b`;
for half-open intervals this enforces the range to have the given length with step `(b-a)/length`.