### PR TITLE
Remove EllipsisNotation.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,9 @@ version = "0.5.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-EllipsisNotation = "0.4, 1.0"
 julia = "0.7, 1"
 
 [extras]

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -9,9 +9,6 @@ import Statistics: mean
 
 using Dates
 
-using EllipsisNotation
-import EllipsisNotation: Ellipsis
-
 export AbstractInterval, Interval, OpenInterval, ClosedInterval,
             ⊇, .., ±, ordered, width, duration, leftendpoint, rightendpoint, endpoints,
             isopenset, isclosedset, isleftclosed, isrightclosed,

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -81,12 +81,8 @@ convert(::Type{TypedEndpointsInterval{L,R}}, d::Interval{L,R}) where {L,R} = d
     iv = l..r
 
 Construct a ClosedInterval `iv` spanning the region from `l` to `r`.
-
-(The symbol `..` is the same as in the package EllipsisNotation.jl.)
 """
-..
-
-(::Ellipsis)(x, y) = ClosedInterval(x, y)
+..(x, y) = ClosedInterval(x, y)
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,11 +22,7 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
 struct IncompleteInterval <: AbstractInterval{Int} end
 
 @testset "IntervalSets" begin
-    if VERSION >= v"1.1"
-        # Julia 1.0 defines getindex(a::GenericArray, i...) in Test,
-        # which could cause an ambiguity with getindex(A::AbstractArray, ::EllipsisNotation.Ellipsis)
-        @test isempty(detect_ambiguities(IntervalSets, Base, Core))
-    end
+    @test isempty(detect_ambiguities(IntervalSets, Base, Core))
 
     @test ordered(2, 1) == (1, 2)
     @test ordered(1, 2) == (1, 2)


### PR DESCRIPTION
This reverts #57, making the package depend only on the standard library.