### PR TITLE
support ± for CartesianIndex

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -97,6 +97,7 @@ Construct a ClosedInterval `iv` spanning the region from
 """
 ±(x, y) = ClosedInterval(x - y, x + y)
 ±(x::CartesianIndex, y) = (xy = y * one(x); map(ClosedInterval, (x - xy).I, (x + xy).I))
+±(x::CartesianIndex, y::CartesianIndex) = ClosedInterval(x-y, x+y)
 
 show(io::IO, I::ClosedInterval) = print(io, leftendpoint(I), "..", rightendpoint(I))
 show(io::IO, I::OpenInterval) = print(io, leftendpoint(I), "..", rightendpoint(I), " (open)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,10 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         O = @inferred(CartesianIndex(1, 2, 3, 4) ± 2)
         @test O == (-1..3, 0..4, 1..5, 2..6)
 
+        x, y = CartesianIndex(1, 2, 3, 4), CartesianIndex(1, 2, 3, 4)
+        O = @inferred x±y
+        @test O == ClosedInterval(x-y, x+y)
+
         @test eltype(I) == Int
         @test eltype(M) == Float64
 


### PR DESCRIPTION
In Base we have `CartesianIndex(a, b):CartesianIndex(c,d)` construct
the region `CartesianIndices((a:c, b:d))`. Similiarly, we would
want to have `CartesianIndex(a,b)..CartesianIndex(c,d)` mean the
same thing.

This commit fixes the ± constructor for CartesianIndex