### PR TITLE
Add methods for `⊊` and `⊋`

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -2,7 +2,7 @@ module IntervalSets
 
 using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, issubset, ==, hash,
-             union, intersect, minimum, maximum, extrema, range, clamp, ⊇
+             union, intersect, minimum, maximum, extrema, range, clamp, ⊇, ⊊, ⊋
 
 using Statistics
 import Statistics: mean
@@ -212,6 +212,8 @@ function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsI
 end
 
 ⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)
+⊊(A::AbstractInterval, B::AbstractInterval) = (A ≠ B) & (A ⊆ B)
+⊋(A::AbstractInterval, B::AbstractInterval) = (A ≠ B) & (A ⊇ B)
 if VERSION < v"1.1.0-DEV.123"
     issubset(x, B::AbstractInterval) = issubset(convert(AbstractInterval, x), B)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,12 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test (ClosedInterval(7, 9) ⊆ I) == false
         @test I ⊇ I
         @test I ⊇ ClosedInterval(1, 2)
+        @test !(I ⊊ I)
+        @test !(I ⊋ I)
+        @test !(I ⊊ J)
+        @test !(J ⊋ I)
+        @test J ⊊ I
+        @test I ⊋ J
 
         @test hash(1..3) == hash(1.0..3.0)
 


### PR DESCRIPTION
This PR fixes #89.