### PR TITLE
Fix type promotion

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -27,7 +27,7 @@ mathematical notation, the constructed range is `(left, right)`.
 const OpenInterval{T} = Interval{:open,:open,T}
 
 Interval{L,R,T}(i::AbstractInterval) where {L,R,T} = Interval{L,R,T}(endpoints(i)...)
-Interval{L,R}(left, right) where {L,R} = Interval{L,R,promote_type(typeof(left), typeof(right))}(left,right)
+Interval{L,R}(left, right) where {L,R} = Interval{L,R}(promote(left,right)...)
 Interval{L,R}(left::T, right::T) where {L,R,T} = Interval{L,R,T}(left, right)
 Interval(left, right) = ClosedInterval(left, right)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ closedendpoints(I::MyUnitInterval) = (I.isleftclosed,I.isrightclosed)
 struct IncompleteInterval <: AbstractInterval{Int} end
 
 @testset "IntervalSets" begin
-    @test isempty(detect_ambiguities(IntervalSets, Base, Core))
+    @test isempty(detect_ambiguities(IntervalSets))
 
     @test ordered(2, 1) == (1, 2)
     @test ordered(1, 2) == (1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @testset "Basic Closed Sets" begin
         @test_throws ErrorException :a .. "b"
         @test_throws ErrorException 1 .. missing
+        @test_throws ErrorException 1u"m" .. 2u"s"
         I = 0..3
         @test I === ClosedInterval(0,3) === ClosedInterval{Int}(0,3) ===
                  Interval(0,3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
     @testset "Basic Closed Sets" begin
         @test_throws ErrorException :a .. "b"
+        @test_throws ErrorException 1 .. missing
         I = 0..3
         @test I === ClosedInterval(0,3) === ClosedInterval{Int}(0,3) ===
                  Interval(0,3)
@@ -638,12 +639,6 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test_throws InexactError convert(OpenInterval, I)
         @test I ∩ I === 0..1
         @test I ∩ (0.0..0.5) === 0.0..0.5
-    end
-
-    @testset "Missing endpoints" begin
-        # TODO: Remove this testset in the next breaking release (#94)
-        @test ismissing(2 in 1..missing)
-        @test_broken ismissing(2 in missing..1)  # would be fixed by julialang#31171
     end
 
     @testset "in" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @test ordered(Float16(1), 2) == (1, 2)
 
     @testset "Basic Closed Sets" begin
-        @test_throws ArgumentError :a .. "b"
+        @test_throws ErrorException :a .. "b"
         I = 0..3
         @test I === ClosedInterval(0,3) === ClosedInterval{Int}(0,3) ===
                  Interval(0,3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Dates
 using Statistics
 import Statistics: mean
 using Random
+using Unitful
 
 import IntervalSets: Domain, endpoints, closedendpoints, TypedEndpointsInterval
 
@@ -138,6 +139,13 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test duration(1..2) == 2
         # duration deliberately not defined for non-integer intervals
         @test_throws MethodError duration(1.2..2.4)
+    end
+
+    @testset "Unitful interval" begin
+        @test 1.5u"m" in 1u"m" .. 2u"m"
+        @test 1500u"μm" in 1u"mm" .. 1u"m"
+        @test !(500u"μm" in 1u"mm" .. 1u"m")
+        @test 1u"m" .. 2u"m" == 1000u"mm" .. 2000u"mm"
     end
 
     @testset "Day interval" begin


### PR DESCRIPTION
This PR fixes #86.

```julia
julia> using Unitful: m, s

julia> using IntervalSets

julia> x = 1m .. 5m
1 m..5 m

julia> y = 1m .. 2s
ERROR: promotion of types Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}} and Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}} failed to change any arguments
Stacktrace:
 [1] error(::String, ::String, ::String)
   @ Base ./error.jl:42
 [2] sametype_error(input::Tuple{Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}})
   @ Base ./promotion.jl:374
 [3] not_sametype(x::Tuple{Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}}, y::Tuple{Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}}})
   @ Base ./promotion.jl:368
 [4] promote
   @ ./promotion.jl:351 [inlined]
 [5] (ClosedInterval)(left::Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, right::Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}})
   @ IntervalSets ~/.julia/dev/IntervalSets/src/interval.jl:30
 [6] ..(x::Unitful.Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}, y::Unitful.Quantity{Int64, 𝐓, Unitful.FreeUnits{(s,), 𝐓, nothing}})
   @ IntervalSets ~/.julia/dev/IntervalSets/src/interval.jl:85
 [7] top-level scope
   @ REPL[4]:1
```

Note that we now have a new issue around `missing`. I'll open it soon.