### PR TITLE
Add deprecated message for conversions number to interval

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -242,7 +242,7 @@ include("interval.jl")
 # convert numbers to intervals
 # TODO: These conversions will be removed in the next breaking release (#97)
 function convert(::Type{AbstractInterval}, x::Number)
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     x..x
 end
 function convert(::Type{AbstractInterval{T}}, x::Number) where T

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -240,15 +240,31 @@ duration(A::TypedEndpointsInterval{:closed,:closed,Date}) = max(0, Dates.days(A.
 include("interval.jl")
 
 # convert numbers to intervals
-convert(::Type{AbstractInterval}, x::Number) = x..x
-convert(::Type{AbstractInterval{T}}, x::Number) where T =
+# TODO: These conversions will be removed in the next breaking release (#97)
+function convert(::Type{AbstractInterval}, x::Number)
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    x..x
+end
+function convert(::Type{AbstractInterval{T}}, x::Number) where T
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
-convert(::Type{TypedEndpointsInterval{:closed,:closed}}, x::Number) = x..x
-convert(::Type{TypedEndpointsInterval{:closed,:closed,T}}, x::Number) where T =
+end
+function convert(::Type{TypedEndpointsInterval{:closed,:closed}}, x::Number)
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    x..x
+end
+function convert(::Type{TypedEndpointsInterval{:closed,:closed,T}}, x::Number) where T
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
-convert(::Type{ClosedInterval}, x::Number) = x..x
-convert(::Type{ClosedInterval{T}}, x::Number) where T =
+end
+function convert(::Type{ClosedInterval}, x::Number)
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    x..x
+end
+function convert(::Type{ClosedInterval{T}}, x::Number) where T
+    Base.depwarn("`The conversion number to interval will be removed.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
+end
 
 include("findall.jl")
 

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -246,23 +246,23 @@ function convert(::Type{AbstractInterval}, x::Number)
     x..x
 end
 function convert(::Type{AbstractInterval{T}}, x::Number) where T
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
 end
 function convert(::Type{TypedEndpointsInterval{:closed,:closed}}, x::Number)
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     x..x
 end
 function convert(::Type{TypedEndpointsInterval{:closed,:closed,T}}, x::Number) where T
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
 end
 function convert(::Type{ClosedInterval}, x::Number)
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     x..x
 end
 function convert(::Type{ClosedInterval{T}}, x::Number) where T
-    Base.depwarn("`The conversion number to interval will be removed.", :convert)
+    Base.depwarn("`The conversion number to interval will be removed; construct an interval explicitly, e.g., `x..x`.", :convert)
     convert(AbstractInterval{T}, convert(AbstractInterval, x))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test 1.0..2.0 === 1.0..2 === 1..2.0 === ClosedInterval{Float64}(1..2) ===
                 Interval(1.0,2.0)
 
+        # TODO: Remove this test in the next breaking release (#97)
         @test convert(AbstractInterval, 1.0) ==
                 convert(AbstractInterval{Float64}, 1) ==
                 convert(TypedEndpointsInterval{:closed,:closed}, 1.0) ==


### PR DESCRIPTION
This PR fixes #97.

I just removed the conversion methods. Should we add deprecation messages instead?
I guess the conversions are probably not well used.
