### PR TITLE
Add deprecated message for `1..missing`

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -27,7 +27,14 @@ mathematical notation, the constructed range is `(left, right)`.
 const OpenInterval{T} = Interval{:open,:open,T}
 
 Interval{L,R,T}(i::AbstractInterval) where {L,R,T} = Interval{L,R,T}(endpoints(i)...)
-Interval{L,R}(left, right) where {L,R} = Interval{L,R,promote_type(typeof(left), typeof(right))}(left,right)
+function Interval{L,R}(left, right) where {L,R}
+    # TODO: Replace the retrun value with `Interval{L,R}(promote(left,right)...)`. (#93)
+    T = promote_type(typeof(left), typeof(right))
+    if !isconcretetype(T)
+        Base.depwarn("`The input types cannot be promoted to a concrete type.", :Interval)
+    end
+    Interval{L,R,T}(left,right)
+end
 Interval{L,R}(left::T, right::T) where {L,R,T} = Interval{L,R,T}(left, right)
 Interval(left, right) = ClosedInterval(left, right)
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -31,7 +31,7 @@ function Interval{L,R}(left, right) where {L,R}
     # TODO: Replace the retrun value with `Interval{L,R}(promote(left,right)...)`. (#93)
     T = promote_type(typeof(left), typeof(right))
     if !isconcretetype(T)
-        Base.depwarn("`The input types cannot be promoted to a concrete type.", :Interval)
+        Base.depwarn("`Promotion to a concrete type failed and will error in the next release; consider constructing this interval as `Interval{L,R,$(typejoin(typeof(left),typeof(right)))}(left, right)`.", :Interval)
     end
     Interval{L,R,T}(left,right)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -636,6 +636,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     end
 
     @testset "Missing endpoints" begin
+        # TODO: Remove this testset in the next breaking release (#94)
         @test ismissing(2 in 1..missing)
         @test_broken ismissing(2 in missing..1)  # would be fixed by julialang#31171
     end


### PR DESCRIPTION
This PR adds a deprecated message in the `Interval` constructor, without any breaking changes. (#94)