### PR TITLE
Add support for `rand(1..2)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -6,6 +6,7 @@ import Base: eltype, convert, show, in, length, isempty, isequal, issubset, ==, 
 
 using Statistics
 import Statistics: mean
+using Random
 
 using Dates
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -231,12 +231,12 @@ end
 
 # random sampling from interval
 Random.gentype(::Type{Interval{L,R,T}}) where {L,R,T} = float(T)
-function Random.rand(rng::AbstractRNG, i::Random.SamplerTrivial{Interval{L,R,T}}) where {L,R,T<:Real}
+function Random.rand(rng::AbstractRNG, i::Random.SamplerTrivial{ClosedInterval{T}}) where {T<:Real}
     _i = i[]
     isempty(_i) && throw(ArgumentError("The interval should be non-empty."))
     a,b = endpoints(_i)
     t = rand(rng, float(T))
-    return t*a+(1-t)*b
+    return clamp(t*a+(1-t)*b, _i)
 end
 
 ClosedInterval{T}(i::AbstractUnitRange{I}) where {T,I<:Integer} = ClosedInterval{T}(minimum(i), maximum(i))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -229,6 +229,14 @@ function _union(A::TypedEndpointsInterval{L1,R1}, B::TypedEndpointsInterval{L2,R
     Interval{L,R}(left, right)
 end
 
+function Random.rand(rng::AbstractRNG, i::Random.SamplerTrivial{Interval{L,R,T}}) where {L,R,T<:Real}
+    _i = i[]
+    isempty(_i) && throw(ArgumentError("The interval should be non-empty."))
+    a,b = endpoints(_i)
+    t = rand(rng)
+    return t*a+(1-t)*b
+end
+
 ClosedInterval{T}(i::AbstractUnitRange{I}) where {T,I<:Integer} = ClosedInterval{T}(minimum(i), maximum(i))
 ClosedInterval(i::AbstractUnitRange{I}) where {I<:Integer} = ClosedInterval{I}(minimum(i), maximum(i))
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -229,11 +229,13 @@ function _union(A::TypedEndpointsInterval{L1,R1}, B::TypedEndpointsInterval{L2,R
     Interval{L,R}(left, right)
 end
 
+# random sampling from interval
+Random.gentype(::Type{Interval{L,R,T}}) where {L,R,T} = float(T)
 function Random.rand(rng::AbstractRNG, i::Random.SamplerTrivial{Interval{L,R,T}}) where {L,R,T<:Real}
     _i = i[]
     isempty(_i) && throw(ArgumentError("The interval should be non-empty."))
     a,b = endpoints(_i)
-    t = rand(rng)
+    t = rand(rng, float(T))
     return t*a+(1-t)*b
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -718,6 +718,34 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test clamp.([pi, 1.0, big(10.)], Ref(2..9.)) == [big(pi), 2, 9]
     end
 
+    @testset "rand" begin
+        @test rand(1..2) isa Float64
+        @test rand(1..2.) isa Float64
+        @test rand(1..big(2)) isa BigFloat
+        @test rand(1..(3//2)) isa Float64
+        @test rand(Int32(1)..Int32(2)) isa Float64
+        @test rand(Float32(1)..Float32(2)) isa Float32
+        @test_throws ArgumentError rand(2..1)
+
+        i1 = 1..2
+        i2 = 3e100..3e100
+        i3 = 1..typemax(Float64)
+        i4 = typemin(Float64)..typemax(Float64)
+        i5 = typemin(Float64)..1
+        for _ in 1:100
+            rand(i1) in i1
+            rand(i2) in i2
+            rand(i3) in i3
+            rand(i4) in i4
+            rand(i5) in i5
+            rand(i1,10) ⊆ i1
+            rand(i2,10) ⊆ i2
+            rand(i3,10) ⊆ i3
+            rand(i4,10) ⊆ i4
+            rand(i5,10) ⊆ i5
+        end
+    end
+
     @testset "IteratorSize" begin
         @test Base.IteratorSize(ClosedInterval) == Base.SizeUnknown()
     end


### PR DESCRIPTION
This PR fixes #95.

```julia
julia> using IntervalSets, Dates

julia> rand(1..2)  # Sampling from uniform distion on 1..2
1.525710842368245

julia> rand(1..2, 3)  # Get three samples
3-element Vector{Float64}:
 1.0470183699383326
 1.406808529012634
 1.2230905556202805

julia> rand(42..42)  # Accepts closed inerval with zero width.
42.0

julia> rand(Interval{:open,:closed}(1,3))  # Only ClosedInterval is supported

ERROR: ArgumentError: Sampler for this object is not defined
Stacktrace:
 [1] Random.Sampler(#unused#::Type{Random.TaskLocalRNG}, sp::Random.SamplerTrivial{Interval{:open, :closed, Int64}, Float64}, #unused#::Val{1})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:146
 [2] Random.Sampler(rng::Random.TaskLocalRNG, x::Random.SamplerTrivial{Interval{:open, :closed, Int64}, Float64}, r::Val{1})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:140
 [3] rand(rng::Random.TaskLocalRNG, X::Random.SamplerTrivial{Interval{:open, :closed, Int64}, Float64}) (repeats 2 times)
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:254
 [4] rand(X::Interval{:open, :closed, Int64})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:259
 [5] top-level scope
   @ REPL[5]:1

julia> rand(42..41)  # Error on empty interval
ERROR: ArgumentError: The interval should be non-empty.
Stacktrace:
 [1] rand(rng::Random.TaskLocalRNG, i::Random.SamplerTrivial{ClosedInterval{Int64}, Float64})
   @ IntervalSets ~/.julia/dev/IntervalSets/src/interval.jl:236
 [2] rand
   @ ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:254 [inlined]
 [3] rand(X::ClosedInterval{Int64})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:259
 [4] top-level scope
   @ REPL[6]:1

julia> rand(Date(2022,04,10)..Date(2022,04,12))  # Only ClosedInterval{<:Real} is supported
ERROR: MethodError: no method matching AbstractFloat(::Type{Date})
Closest candidates are:
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at ~/julia/julia-1.7.1/share/julia/base/char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number at ~/julia/julia-1.7.1/share/julia/base/twiceprecision.jl:255
  (::Type{T})(::Complex) where T<:Real at ~/julia/julia-1.7.1/share/julia/base/complex.jl:44
  ...
Stacktrace:
 [1] float(x::Type)
   @ Base ./float.jl:269
 [2] gentype(#unused#::Type{ClosedInterval{Date}})
   @ IntervalSets ~/.julia/dev/IntervalSets/src/interval.jl:233
 [3] Random.SamplerTrivial(x::ClosedInterval{Date})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:180
 [4] Random.Sampler(#unused#::Type{Random.TaskLocalRNG}, x::ClosedInterval{Date}, #unused#::Val{1})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:182
 [5] Random.Sampler(rng::Random.TaskLocalRNG, x::ClosedInterval{Date}, r::Val{1})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:140
 [6] rand(rng::Random.TaskLocalRNG, X::ClosedInterval{Date})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:254
 [7] rand(X::ClosedInterval{Date})
   @ Random ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Random/src/Random.jl:259
 [8] top-level scope
   @ REPL[7]:1
```
