### PR TITLE
isapprox should work for comparing open and closed intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -144,7 +144,6 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 ==(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) && isempty(B)
 
 function isapprox(A::AbstractInterval, B::AbstractInterval; atol=0, rtol=Base.rtoldefault(eltype(A), eltype(B), atol), kwargs...)
-    closedendpoints(A) != closedendpoints(B) && error("Comparing intervals with different closedness is not defined")
     isempty(A) != isempty(B) && return false
     isempty(A) && isempty(B) && return true
     maxabs = max(maximum(abs, endpoints(A)), maximum(abs, endpoints(B)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test 0..1 ≈ eps()..1
         @test 100.0..100.0 ≉ nextfloat(100.0)..100.0
         @test 3..1 ≈ 5..1
-        @test_throws Exception OpenInterval(0, 1) ≈ ClosedInterval(0, 1)
+        @test OpenInterval(0, 1) ≈ ClosedInterval(0, 1)
     end
 
     @testset "Convert" begin


### PR DESCRIPTION
Something like `OpenInterval(0,1)` should certainly be approximately `ClosedInterval(0,1)` as they are closer to each other than the following which returns true:
```julia
julia> nextfloat(0.)..prevfloat(1.) ≈ 0..1
true
```