### PR TITLE
Display intervals in isapprox error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -143,8 +143,13 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 ==(A::TypedEndpointsInterval{L,R}, B::TypedEndpointsInterval{L,R}) where {L,R} = (leftendpoint(A) == leftendpoint(B) && rightendpoint(A) == rightendpoint(B)) || (isempty(A) && isempty(B))
 ==(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) && isempty(B)
 
+@noinline function throw_closednesserror(A, B)
+    errstr = "comparing intervals with different closedness is not defined (received $A and $B)"
+    throw(ArgumentError(errstr))
+end
+
 function isapprox(A::AbstractInterval, B::AbstractInterval; atol=0, rtol=Base.rtoldefault(eltype(A), eltype(B), atol), kwargs...)
-    closedendpoints(A) != closedendpoints(B) && error("Comparing intervals with different closedness is not defined")
+    closedendpoints(A) != closedendpoints(B) && throw_closednesserror(A, B)
     isempty(A) != isempty(B) && return false
     isempty(A) && isempty(B) && return true
     maxabs = max(maximum(abs, endpoints(A)), maximum(abs, endpoints(B)))


### PR DESCRIPTION
This makes debugging easier. After this PR,
```julia
julia> i1 = Interval{:open,:closed}(1,2)
1..2 (open–closed)

julia> i2 = Interval{:closed,:open}(1,2)
1..2 (closed–open)

julia> isapprox(i1, i2)
ERROR: ArgumentError: comparing intervals with different closedness is not defined (received 1..2 (open–closed) and 1..2 (closed–open))
Stacktrace:
 [1] throw_closednesserror(A::Interval{:open, :closed, Int64}, B::Interval{:closed, :open, Int64})
   @ IntervalSets ~/Dropbox/JuliaPackages/IntervalSets.jl/src/IntervalSets.jl:148
 [2] isapprox(A::Interval{:open, :closed, Int64}, B::Interval{:closed, :open, Int64}; atol::Int64, rtol::Int64, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ IntervalSets ~/Dropbox/JuliaPackages/IntervalSets.jl/src/IntervalSets.jl:152
 [3] isapprox(A::Interval{:open, :closed, Int64}, B::Interval{:closed, :open, Int64})
   @ IntervalSets ~/Dropbox/JuliaPackages/IntervalSets.jl/src/IntervalSets.jl:151
 [4] top-level scope
   @ REPL[4]:1
```