### PR TITLE
Specialize `angle` and `sign`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -2,7 +2,8 @@ module IntervalSets
 
 using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
-             union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
+             union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋,
+             angle, sign
 
 using Statistics
 import Statistics: mean
@@ -94,6 +95,10 @@ function supremum(d::AbstractInterval{T}) where T
 end
 
 mean(d::AbstractInterval) = (leftendpoint(d) + rightendpoint(d))/2
+
+complexlength(d::AbstractInterval) = rightendpoint(d)-leftendpoint(d)
+angle(d::AbstractInterval) = angle(complexlength(d))
+sign(d::AbstractInterval) = sign(complexlength(d))
 
 """
     w = width(iv)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -849,5 +849,11 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         @test float(i4) == i4
     end
 
+    @testset "phase for complex intervals" begin
+        iv = 0..2im
+        @test angle(iv) ≈ pi/2
+        @test sign(iv) ≈ cis(pi/2)
+    end
+
     include("findall.jl")
 end


### PR DESCRIPTION
These were being specialized in `ApproxFunBase`, but it's best to avoid the type-piracy and move the methods to this package. These are useful for complex intervals.
```julia
julia> iv = 0..im
0 + 0im..0 + 1im

julia> angle(iv) ≈ pi/2
true
```