### PR TITLE
Fix spacing with `Base.show`

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -94,10 +94,10 @@ Construct a ClosedInterval `iv` spanning the region from
 ±(x, y) = ClosedInterval(x - y, x + y)
 ±(x::CartesianIndex, y::CartesianIndex) = ClosedInterval(x-y, x+y)
 
-show(io::IO, I::ClosedInterval) = print(io, leftendpoint(I), "..", rightendpoint(I))
-show(io::IO, I::OpenInterval) = print(io, leftendpoint(I), "..", rightendpoint(I), " (open)")
-show(io::IO, I::Interval{:open,:closed}) = print(io, leftendpoint(I), "..", rightendpoint(I), " (open–closed)")
-show(io::IO, I::Interval{:closed,:open}) = print(io, leftendpoint(I), "..", rightendpoint(I), " (closed–open)")
+show(io::IO, I::ClosedInterval) = print(io, leftendpoint(I), " .. ", rightendpoint(I))
+show(io::IO, I::OpenInterval) = print(io, leftendpoint(I), " .. ", rightendpoint(I), " (open)")
+show(io::IO, I::Interval{:open,:closed}) = print(io, leftendpoint(I), " .. ", rightendpoint(I), " (open-closed)")
+show(io::IO, I::Interval{:closed,:open}) = print(io, leftendpoint(I), " .. ", rightendpoint(I), " (closed-open)")
 
 # The following are not typestable for mixed endpoint types
 _left_intersect_type(::Type{Val{:open}}, ::Type{Val{L2}}, a1, a2) where L2 = a1 < a2 ? (a2,L2) : (a1,:open)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         I = 0..3
         @test I === ClosedInterval(0,3) === ClosedInterval{Int}(0,3) ===
                  Interval(0,3)
-        @test string(I) == "0..3"
+        @test string(I) == "0 .. 3"
         @test @inferred(UnitRange(I)) === 0:3
         @test @inferred(range(I)) === 0:3
         @test @inferred(UnitRange{Int16}(I)) === Int16(0):Int16(3)
@@ -47,7 +47,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         K = 5..4
         L = 3 ± 2
         M = @inferred(ClosedInterval(2, 5.0))
-        @test string(M) == "2.0..5.0"
+        @test string(M) == "2.0 .. 5.0"
         N = @inferred(ClosedInterval(UInt8(255), 300))
 
         x, y = CartesianIndex(1, 2, 3, 4), CartesianIndex(1, 2, 3, 4)


### PR DESCRIPTION
This PR fixes #134.

**Before this PR**
```julia
julia> using IntervalSets

julia> 1..2
1..2

julia> Interval{:open,:closed}(1,2)
1..2 (open-closed)
```

**After this PR**
```julia
julia> using IntervalSets

julia> 1..2
1 .. 2

julia> Interval{:open,:closed}(1,2)
1 .. 2 (open-closed)
```

