### PR TITLE
Fix broken tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,6 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
         @test 1.5 ∉ 0..1
         @test 1.5 ∉ 2..3
-        @test_broken (0..1) ∪ (2..3) ≠ 0..3
         # even though A and B contain all Float32s between their extrema,
         # union should not return an interval as there exists a Float64
         # inbetween

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,18 +94,17 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
         @test 1.5 ∉ 0..1
         @test 1.5 ∉ 2..3
-        # even though A and B contain all Float32s between their extrema,
-        # union should not return an interval as there exists a Float64
-        # inbetween
+        # Throw error if the union is not an interval.
+        @test_throws ArgumentError (0..1) ∪ (2..3)
+        # Even though A and B contain all Float16s between their extrema,
+        # union should not defined because there exists a Float64 inbetween.
+        @test_throws ArgumentError A ∪ B
         x32 = nextfloat(rightendpoint(A))
         x64 = nextfloat(Float64(rightendpoint(A)))
         @test x32 ∉ A
         @test x32 ∈ B
         @test x64 ∉ A
         @test x64 ∉ B
-        # these tests
-        @test_broken x32 ∈ A ∪ B
-        @test_broken x64 ∉ A ∪ B
 
         @test J ⊆ L
         @test (L ⊆ J) == false


### PR DESCRIPTION
This PR fixes https://github.com/JuliaMath/IntervalSets.jl/issues/131.

The `@test_broken`s are not broken, and the thrown `ArgumentError`s are valid.