### PR TITLE
Move Statistics to an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,21 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[weakdeps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extensions]
+IntervalSetsStatisticsExt = "Statistics"
+
 [compat]
 julia = "1.6"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test", "Random", "OffsetArrays", "Unitful"]
+test = ["Test", "Random", "OffsetArrays", "Statistics", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/ext/IntervalSetsStatisticsExt.jl
+++ b/ext/IntervalSetsStatisticsExt.jl
@@ -1,0 +1,8 @@
+module IntervalSetsStatisticsExt
+
+using IntervalSets
+using Statistics
+
+Statistics.mean(d::AbstractInterval) = IntervalSets.mean(d)
+
+end

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -4,8 +4,6 @@ using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
 
-using Statistics
-import Statistics: mean
 using Random
 
 using Dates
@@ -282,5 +280,9 @@ end
 
 include("interval.jl")
 include("findall.jl")
+
+if !isdefined(Base, :get_extension)
+    include("../ext/IntervalSetsStatisticsExt.jl")
+end
 
 end # module


### PR DESCRIPTION
On master, using Julia v1.10.0-alpha1,
```julia
julia> @time_imports using IntervalSets
               ┌ 8.5 ms SparseArrays.CHOLMOD.__init__() 92.98% compilation time
    498.9 ms  SparseArrays 11.35% compilation time
      0.8 ms  Statistics
     14.6 ms  IntervalSets
```
In this PR, `Statistics` (and hence `SparseArrays`) is moved to an extension, so
```julia
julia> @time_imports using IntervalSets
     16.8 ms  IntervalSets
```