### PR TITLE
update README not to encourage type-piracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ This package represents intervals of an ordered set. For an interval
 spanning from `a` to `b`, all values `x` that lie between `a` and `b`
 are defined as being members of the interval.
 
-This package is intended to implement a "minimal" foundation for
-intervals upon which other packages might build. In particular, we
-*encourage* [type-piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy)
-for the reason that only one interval package can
-unambiguously define the `..` and `±` operators (see below).
-
 Currently this package defines one concrete type, `Interval`.
 These define the set spanning from `a` to `b`, meaning the
 interval is defined as the set `{x}` satisfying `a ≤ x ≤ b`. This is


### PR DESCRIPTION
This PR just removes the paragraph that encourages type-piracy. (alternative to #56)

The removed paragraph is:

>This package is intended to implement a "minimal" foundation for intervals upon which other packages might build. In particular, we encourage [type-piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) for the reason that only one interval package can unambiguously define the `..` and `±` operators (see below).

The reasons why I would like to remove that are:

* Generally, we would like to avoid type-piracy
  * Type-piracies exist on some packages, and should be fixed. (https://github.com/JuliaMath/IntervalSets.jl/pull/127)
* If someone wants some operations to `Interval`, PRs are welcome.
  * If the new operation does not fit `Interval`, you can just add the method to your wrapper type. (e.g. `struct YourInterval{L,R,T} i::Interval{L,R,T} end`)
