### PR TITLE
Deprecate methods for `eltype` and add `boundstype`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -63,7 +63,15 @@ isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
 boundstype(i::AbstractInterval) = boundstype(typeof(i))
 boundstype(::Type{I}) where {I<:AbstractInterval{T}} where T = T
-@deprecate Base.eltype(I::Type{<:AbstractInterval}) boundstype(I) false
+
+@static if VERSION < v"1.9"
+    function Base.eltype(I::Type{<:AbstractInterval})
+        Base.depwarn("`eltype` for `AbstractInterval` will be replaced with `boundstype` in the next breaking release (v0.8.0).", :eltype)
+        boundstype(I)
+    end
+else
+    @deprecate Base.eltype(I::Type{<:AbstractInterval}) boundstype(I) false
+end
 
 convert(::Type{AbstractInterval}, i::AbstractInterval) = i
 convert(::Type{AbstractInterval{T}}, i::AbstractInterval{T}) where T = i

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -62,8 +62,8 @@ isclosedset(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
 isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
 boundstype(i::AbstractInterval) = boundstype(typeof(i))
-boundstype(::Type{AbstractInterval{T}}) where {T} = T
 boundstype(::Type{I}) where {I<:AbstractInterval{T}} where T = T
+@deprecate Base.eltype(I::Type{<:AbstractInterval}) boundstype(I) false
 
 convert(::Type{AbstractInterval}, i::AbstractInterval) = i
 convert(::Type{AbstractInterval{T}}, i::AbstractInterval{T}) where T = i

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -63,7 +63,7 @@ isclosedset(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
 isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
 eltype(::Type{AbstractInterval{T}}) where {T} = T
-@pure eltype(::Type{I}) where {I<:AbstractInterval} = eltype(supertype(I))
+eltype(::Type{I}) where {I<:AbstractInterval{T}} where T = T
 
 convert(::Type{AbstractInterval}, i::AbstractInterval) = i
 convert(::Type{AbstractInterval{T}}, i::AbstractInterval{T}) where T = i

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -1,7 +1,6 @@
 module IntervalSets
 
-using Base: @pure
-import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
+import Base: convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
 
 using Random
@@ -62,8 +61,9 @@ isclosedset(d::AbstractInterval) = isleftclosed(d) && isrightclosed(d)
 "Is the interval open?"
 isopenset(d::AbstractInterval) = isleftopen(d) && isrightopen(d)
 
-eltype(::Type{AbstractInterval{T}}) where {T} = T
-eltype(::Type{I}) where {I<:AbstractInterval{T}} where T = T
+boundstype(i::AbstractInterval) = boundstype(typeof(i))
+boundstype(::Type{AbstractInterval{T}}) where {T} = T
+boundstype(::Type{I}) where {I<:AbstractInterval{T}} where T = T
 
 convert(::Type{AbstractInterval}, i::AbstractInterval) = i
 convert(::Type{AbstractInterval{T}}, i::AbstractInterval{T}) where T = i
@@ -141,7 +141,7 @@ isequal(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) & ise
 ==(A::TypedEndpointsInterval{L,R}, B::TypedEndpointsInterval{L,R}) where {L,R} = (leftendpoint(A) == leftendpoint(B) && rightendpoint(A) == rightendpoint(B)) || (isempty(A) && isempty(B))
 ==(A::TypedEndpointsInterval, B::TypedEndpointsInterval) = isempty(A) && isempty(B)
 
-function isapprox(A::AbstractInterval, B::AbstractInterval; atol=0, rtol=Base.rtoldefault(eltype(A), eltype(B), atol), kwargs...)
+function isapprox(A::AbstractInterval, B::AbstractInterval; atol=0, rtol=Base.rtoldefault(boundstype(A), boundstype(B), atol), kwargs...)
     closedendpoints(A) != closedendpoints(B) && error("Comparing intervals with different closedness is not defined")
     isempty(A) != isempty(B) && return false
     isempty(A) && isempty(B) && return true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,8 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
         @test boundstype(I) == Int
         @test boundstype(M) == Float64
+        @test eltype(I) == Int
+        @test eltype(M) == Float64
 
         @test !isempty(I)
         @test isempty(J)
@@ -643,6 +645,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @testset "Custom intervals" begin
         I = MyUnitInterval(true,true)
         @test boundstype(I) == boundstype(typeof(I)) == Int
+        @test eltype(I) == eltype(typeof(I)) == Int
         @test leftendpoint(I) == 0
         @test rightendpoint(I) == 1
         @test isleftclosed(I)
@@ -823,6 +826,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @testset "IncompleteInterval" begin
         I = IncompleteInterval()
         @test boundstype(I) === Int
+        @test eltype(I) === Int
         @test_throws ErrorException endpoints(I)
         @test_throws ErrorException closedendpoints(I)
         @test_throws MethodError 2 in I

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ import Statistics: mean
 using Random
 using Unitful
 
-import IntervalSets: Domain, endpoints, closedendpoints, TypedEndpointsInterval
+import IntervalSets: Domain, endpoints, closedendpoints, TypedEndpointsInterval, boundstype
 
 struct MyClosedUnitInterval <: TypedEndpointsInterval{:closed,:closed,Int} end
 endpoints(::MyClosedUnitInterval) = (0,1)
@@ -54,8 +54,8 @@ struct IncompleteInterval <: AbstractInterval{Int} end
         O = @inferred x±y
         @test O == ClosedInterval(x-y, x+y)
 
-        @test eltype(I) == Int
-        @test eltype(M) == Float64
+        @test boundstype(I) == Int
+        @test boundstype(M) == Float64
 
         @test !isempty(I)
         @test isempty(J)
@@ -642,7 +642,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
     @testset "Custom intervals" begin
         I = MyUnitInterval(true,true)
-        @test eltype(I) == eltype(typeof(I)) == Int
+        @test boundstype(I) == boundstype(typeof(I)) == Int
         @test leftendpoint(I) == 0
         @test rightendpoint(I) == 1
         @test isleftclosed(I)
@@ -822,7 +822,7 @@ struct IncompleteInterval <: AbstractInterval{Int} end
 
     @testset "IncompleteInterval" begin
         I = IncompleteInterval()
-        @test eltype(I) === Int
+        @test boundstype(I) === Int
         @test_throws ErrorException endpoints(I)
         @test_throws ErrorException closedendpoints(I)
         @test_throws MethodError 2 in I


### PR DESCRIPTION
Closes #115 ~~and #122~~.

We had a long discussion about `eltype`, and I believe removing them is the best. (https://github.com/JuliaMath/IntervalSets.jl/issues/115#issuecomment-1219278427)

* `eltype` should not be defined for non-iterable object
* We can keep maintaining the implementation as a different function.
