### PR TITLE
Bump version to `v0.7.7`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.8.0"
+version = "0.7.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
x-ref: https://github.com/JuliaMath/IntervalSets.jl/pull/135#issuecomment-1656783652

Note that there are no differences from `v0.7.5`.