### PR TITLE
Fix branch name in `docs.yml`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Documentation
 on:
   push:
-    branches: [main]
+    branches: [master]
     tags: [v*]
   pull_request:
 jobs:


### PR DESCRIPTION
This PR fixes `docs.yml` introduced in https://github.com/JuliaMath/IntervalSets.jl/pull/152. (Maybe, we can change the default branch from `master` to `main` later)