### PR TITLE
move Domain to DomainSetsCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.7.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DomainSetsCore = "b5e7cfa8-5ebe-46e7-951c-e7d99cb94c6d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -15,6 +16,7 @@ IntervalSetsStatisticsExt = "Statistics"
 
 [compat]
 julia = "1.6"
+DomainSetsCore = "0.1.0"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -4,6 +4,7 @@ using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
 
+using DomainSetsCore
 using Random
 
 using Dates
@@ -16,18 +17,14 @@ export AbstractInterval, Interval, OpenInterval, ClosedInterval,
             searchsorted_interval
 
 """
-A subtype of `Domain{T}` represents a subset of type `T`, that provides `in`.
-"""
-abstract type Domain{T} end
-
-Base.IteratorSize(::Type{<:Domain}) = Base.SizeUnknown()
-Base.isdisjoint(a::Domain, b::Domain) = isempty(a ∩ b)
-
-"""
 A subtype of `AbstractInterval{T}` represents an interval subset of type `T`, that provides
 `endpoints`, `closedendpoints`.
 """
-abstract type AbstractInterval{T} <: Domain{T} end
+abstract type AbstractInterval{T} <: DomainSetsCore.Domain{T} end
+
+Base.IteratorSize(::Type{<:AbstractInterval}) = Base.SizeUnknown()
+Base.isdisjoint(a::AbstractInterval, b::AbstractInterval) = isempty(a ∩ b)
+
 
 
 "A tuple containing the left and right endpoints of the interval."


### PR DESCRIPTION
This PR is an example of how the definition of Domain could move to a DomainSetsCore package.

For now, this does not change anything else apart from the move.

The PR can't be merged until DomainSetsCore has been registered.

A related (and much more invasive) PR for the DomainSets package is https://github.com/JuliaApproximation/DomainSets.jl/pull/140.