### PR TITLE
Add logo to the documentation

### DIFF
--- a/docs/src/assets/logo.svg
+++ b/docs/src/assets/logo.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="114mm"
+   height="70mm"
+   viewBox="0 0 114 70"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.7673703"
+     inkscape:cx="400.02937"
+     inkscape:cy="334.67803"
+     inkscape:window-width="3840"
+     inkscape:window-height="2095"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showgrid="true">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#cb3c33;stroke-width:6.00001;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.675606,57.50048 15.00005,10e-6"
+       id="path2-3-4-7"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:none;stroke:#4063d8;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-6-2-4"
+       cx="78.826828"
+       cy="12.5"
+       rx="7.5000248"
+       ry="7.5" />
+    <path
+       style="fill:none;stroke:#4063d8;stroke-width:6.00001;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.675606,12.50049 36.651199,-4e-4"
+       id="path2-9-2-5"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:#389826;fill-opacity:1;stroke:#389826;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-5-8-54"
+       cx="57.175678"
+       cy="32.500488"
+       rx="7.5000248"
+       ry="7.5" />
+    <ellipse
+       style="fill:#389826;fill-opacity:1;stroke:#389826;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-5-8-5-7"
+       cx="10.175525"
+       cy="32.500488"
+       rx="7.5000248"
+       ry="7.5" />
+    <ellipse
+       style="fill:#cb3c33;fill-opacity:1;stroke:#cb3c33;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-6-2-9-4"
+       cx="57.175678"
+       cy="57.500488"
+       rx="7.5000248"
+       ry="7.5" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#cb3c33;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-6-2-9-5-4"
+       cx="27.175583"
+       cy="57.500488"
+       rx="7.5000248"
+       ry="7.5" />
+    <path
+       style="fill:none;stroke:#9558b2;stroke-width:6.00001;stroke-dasharray:none;stroke-opacity:1"
+       d="m 96.326447,45.00049 -10.000033,1e-5"
+       id="path2-3-4-6-3"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#9558b2;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-6-2-9-5-5-0"
+       cx="-103.82648"
+       cy="45.000488"
+       transform="scale(-1,1)"
+       rx="7.5000248"
+       ry="7.5" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#4063d8;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-6-2-9-5-1-7"
+       cx="27.175583"
+       cy="12.500488"
+       rx="7.5000248"
+       ry="7.5" />
+    <ellipse
+       style="fill:#9558b2;fill-opacity:1;stroke:#9558b2;stroke-width:5.00001;stroke-dasharray:none;stroke-opacity:1"
+       id="path1-5-9-6-7-6-7-8"
+       cx="-78.826393"
+       cy="45.000488"
+       transform="scale(-1,1)"
+       rx="7.5000248"
+       ry="7.5" />
+    <path
+       style="fill:none;stroke:#389826;stroke-width:6.00001;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.67555,32.50049 H 49.675656"
+       id="path4" />
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds a logo to the documentation.

![image](https://github.com/JuliaMath/IntervalSets.jl/assets/7488140/ee88f817-fa0b-477f-a8a8-6112c2852610)

![image](https://github.com/JuliaMath/IntervalSets.jl/assets/7488140/027e7d68-e088-4ba7-8075-45239b66deb1)

I designed this logo with the following in mind:

* Arrange four types of `Interval`.
  * $\textcolor{#4063D8}{I_1}$ : `OpenInterval`
  * $\textcolor{#389826}{I_2}$ : `ClosedInterval`
  * $\textcolor{#9558B2}{I_3}$ : `Interval{:closed, :open}`
  * $\textcolor{#CB3C33}{I_4}$ : `Interval{:open, :closed}`
* Julia logo constructed of the closed endpoints of $\textcolor{#389826}{I_2}$, $\textcolor{#9558B2}{I_3}$, $\textcolor{#CB3C33}{I_4}$.
* Imply set operations such as $\textcolor{#CB3C33}{I_4} = \textcolor{#4063D8}{I_1} \cap \textcolor{#389826}{I_2}$.
* The colors are from [julia-logo-graphics](https://github.com/JuliaLang/julia-logo-graphics).

I hope everyone likes this logo!