### PR TITLE
Add `@iv_str` macro

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -4,7 +4,7 @@ using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
              union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
 
-export AbstractInterval, Interval, OpenInterval, ClosedInterval,
+export AbstractInterval, Interval, OpenInterval, ClosedInterval, @iv_str,
             ⊇, .., ±, ordered, width, leftendpoint, rightendpoint, endpoints,
             isopenset, isclosedset, isleftclosed, isrightclosed,
             isleftopen, isrightopen, closedendpoints,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,22 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @test ordered(1, 2) == (1, 2)
     @test ordered(Float16(1), 2) == (1, 2)
 
+    @testset "iv_str macro" begin
+        @test iv"[1,2]" == 1..2
+        @test iv"[1,2)" == Interval{:closed, :open}(1, 2)
+        @test iv"(1,2]" == Interval{:open, :closed}(1, 2)
+        @test iv"(1,2)" == OpenInterval(1, 2)
+        @test_throws Exception iv"[(1,2)]"
+        @test_throws Exception iv"[1,2,]"
+        @test_throws Exception iv"[(1,2]"
+        @test_throws Exception iv"[(1,,2]"
+        @test_throws Exception iv"[1..2]"
+        @test_throws Exception iv"(1..2)"
+        @test_throws Exception iv"[1...2]"
+        @test_throws Exception iv"(1...2)"
+        @test_throws Exception iv"1..2"
+    end
+
     @testset "Basic Closed Sets" begin
         @test_throws ErrorException :a .. "b"
         @test_throws ErrorException 1 .. missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,10 +37,18 @@ struct IncompleteInterval <: AbstractInterval{Int} end
     @test ordered(Float16(1), 2) == (1, 2)
 
     @testset "iv_str macro" begin
-        @test iv"[1,2]" == 1..2
-        @test iv"[1,2)" == Interval{:closed, :open}(1, 2)
-        @test iv"(1,2]" == Interval{:open, :closed}(1, 2)
-        @test iv"(1,2)" == OpenInterval(1, 2)
+        @test iv"[1,2]" === 1..2
+        @test iv"[1,2)" === Interval{:closed, :open}(1, 2)
+        @test iv"(1,2]" === Interval{:open, :closed}(1, 2)
+        @test iv"(1,2)" === OpenInterval(1, 2)
+
+        for (a,b) in ((1,2), (1.4,3.9), (ℯ,π))
+            @test iv"[a,b]" === a..b
+            @test iv"[a,b)" === Interval{:closed, :open}(a, b)
+            @test iv"(a,b]" === Interval{:open, :closed}(a, b)
+            @test iv"(a,b)" === OpenInterval(a, b)
+        end
+
         @test_throws Exception iv"[(1,2)]"
         @test_throws Exception iv"[1,2,]"
         @test_throws Exception iv"[(1,2]"


### PR DESCRIPTION
This PR fixes #39.

```julia
julia> using Test, IntervalSets

julia> iv"[1,2]"
1 .. 2

julia> iv"[1,2)"
1 .. 2 (closed-open)

julia> iv"(1,2]"
1 .. 2 (open-closed)

julia> iv"(1,2)"
1 .. 2 (open)
```