### PR TITLE
Remove methods for `⊇` and `⊋`

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -168,9 +168,7 @@ function issubset(A::TypedEndpointsInterval{:closed,:closed}, B::TypedEndpointsI
     return isempty(A) | ( (Bl < Al) & (Ar < Br) )
 end
 
-⊇(A::AbstractInterval, B::AbstractInterval) = issubset(B, A)
 ⊊(A::AbstractInterval, B::AbstractInterval) = (A ≠ B) & (A ⊆ B)
-⊋(A::AbstractInterval, B::AbstractInterval) = (A ≠ B) & (A ⊇ B)
 
 const _interval_hash = UInt == UInt64 ? 0x1588c274e0a33ad4 : 0x1e3f7252
 


### PR DESCRIPTION
These are defined in Base.

https://github.com/JuliaLang/julia/blob/3d8b10770a7a7317dde13ae36881991db356326c/base/abstractset.jl#L365

https://github.com/JuliaLang/julia/blob/3d8b10770a7a7317dde13ae36881991db356326c/base/abstractset.jl#L419
