### PR TITLE
Add `ENV["GKSwstype"] = "100"` in `make.jl`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,10 @@
 using IntervalSets
 using Documenter
 
+# We need to set `ENV["GKSwstype"]` to suppress the warning on GitHub Actions.
+# https://github.com/JuliaPlots/Plots.jl/issues/1076#issuecomment-327509819
+ENV["GKSwstype"] = "100"
+
 DocMeta.setdocmeta!(IntervalSets, :DocTestSetup, :(using IntervalSets); recursive=true)
 
 makedocs(;


### PR DESCRIPTION
This PR fixes the following warning message.

>GKS: cannot open display - headless operation mode active

![image](https://github.com/JuliaMath/IntervalSets.jl/assets/7488140/4b7c8410-e6ac-4e05-91fb-61737f72e945)

ref: https://github.com/JuliaPlots/Plots.jl/issues/1076#issuecomment-327509819