### PR TITLE
improve searchsorted_interval performance

### DIFF
--- a/src/findall.jl
+++ b/src/findall.jl
@@ -66,14 +66,15 @@ julia> searchsorted_interval(Float64[], 1..3)
 ```
 """
 function searchsorted_interval(X, i::Interval{L, R}; rev=false) where {L, R}
+    ord = Base.Order.ord(<, identity, rev)
     if rev === true
-        _searchsorted_begin(X, rightendpoint(i), Val(R); rev):_searchsorted_end(X, leftendpoint(i), Val(L); rev)
+        _searchsorted_begin(X, rightendpoint(i), Val(R), ord):_searchsorted_end(X, leftendpoint(i), Val(L), ord)
     else
-        _searchsorted_begin(X, leftendpoint(i), Val(L); rev):_searchsorted_end(X, rightendpoint(i), Val(R); rev)
+        _searchsorted_begin(X, leftendpoint(i), Val(L), ord):_searchsorted_end(X, rightendpoint(i), Val(R), ord)
     end
 end
 
-_searchsorted_begin(X, x, ::Val{:closed}; rev) = searchsortedfirst(X, x; rev, lt=<)
-_searchsorted_begin(X, x,   ::Val{:open}; rev) =  searchsortedlast(X, x; rev, lt=<) + 1
-  _searchsorted_end(X, x, ::Val{:closed}; rev) =  searchsortedlast(X, x; rev, lt=<)
-  _searchsorted_end(X, x,   ::Val{:open}; rev) = searchsortedfirst(X, x; rev, lt=<) - 1
+_searchsorted_begin(X, x, ::Val{:closed}, ord) = searchsortedfirst(X, x, ord)
+_searchsorted_begin(X, x,   ::Val{:open}, ord) =  searchsortedlast(X, x, ord) + 1
+  _searchsorted_end(X, x, ::Val{:closed}, ord) =  searchsortedlast(X, x, ord)
+  _searchsorted_end(X, x,   ::Val{:open}, ord) = searchsortedfirst(X, x, ord) - 1


### PR DESCRIPTION
Kinda hard to make a simple self-contained measurement that shows the performance increase: standalone `searchsorted_interval` calls remain the same with or without this PR. But this change does manifest itself in more complex scenarios: in particular, I found that it eliminates extra allocations in FlexiJoins.jl joins. Both on 1.10 and 1.11!
This would enable me to bump IntervalSets compat in FlexiJoins: now, it's restricted to <= 0.7.7 because of the searchsorted_interval regression afterwards (https://github.com/JuliaAPlavin/FlexiJoins.jl/pull/10).

Supersedes https://github.com/JuliaMath/IntervalSets.jl/pull/168, and relevant for both 1.10 and 1.11.
Basically, here we reduce the number and depth of kwargs calls – Julia doesn't seem to like them :) `Order.ord` is a public and documented function, even though it's rarely used explicitly:
```julia
help?> Base.Order.ord
  ord(lt, by, rev::Union{Bool, Nothing}, order::Ordering=Forward)

  Construct an Ordering object from the same arguments used by sort!. Elements are first transformed by the function by (which may be identity) and are then compared according to either the function lt or an
  existing ordering order. lt should be isless or a function that obeys the same rules as the lt parameter of sort!. Finally, the resulting order is reversed if rev=true.

  Passing an lt other than isless along with an order other than Base.Order.Forward or Base.Order.Reverse is not permitted, otherwise all options are independent and can be used together in all possible
  combinations.

julia> Base.ispublic(Base.Order, :ord)
true
```