### PR TITLE
explicitly qualify `UnitRange` while adding method

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -356,8 +356,8 @@ function Base.OneTo{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:I
 end
 Base.OneTo(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} =
     Base.OneTo{I}(i)
-UnitRange{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:Integer,I<:Integer} = UnitRange{T}(minimum(i), maximum(i))
-UnitRange(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
+Base.UnitRange{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:Integer,I<:Integer} = UnitRange{T}(minimum(i), maximum(i))
+Base.UnitRange(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
 range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
 
 """


### PR DESCRIPTION
Prevent name ambiguity warning during precompilation on nightly Julia.

See:
* https://github.com/JuliaLang/julia/issues/25744
* https://github.com/JuliaLang/julia/issues/57290
* https://github.com/JuliaLang/julia/pull/57311