### PR TITLE
Fix warning on Julia nightly

### DIFF
--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -356,9 +356,9 @@ function Base.OneTo{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:I
 end
 Base.OneTo(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} =
     Base.OneTo{I}(i)
-UnitRange{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:Integer,I<:Integer} = UnitRange{T}(minimum(i), maximum(i))
-UnitRange(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
-range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = UnitRange{I}(i)
+Base.UnitRange{T}(i::TypedEndpointsInterval{:closed,:closed,I}) where {T<:Integer,I<:Integer} = Base.UnitRange{T}(minimum(i), maximum(i))
+Base.UnitRange(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = Base.UnitRange{I}(i)
+range(i::TypedEndpointsInterval{:closed,:closed,I}) where {I<:Integer} = Base.UnitRange{I}(i)
 
 """
     range(i::ClosedInterval; step, length)


### PR DESCRIPTION
It seems that Julia nightly desires all method definitions of names that have not explicitly been imported to be qualified (with e.g. `$module.$name`.