### PR TITLE
Import `UnitRange` explicitly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalSets"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/IntervalSets.jl
+++ b/src/IntervalSets.jl
@@ -2,7 +2,8 @@ module IntervalSets
 
 using Base: @pure
 import Base: eltype, convert, show, in, length, isempty, isequal, isapprox, issubset, ==, hash,
-             union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋
+             union, intersect, minimum, maximum, extrema, range, clamp, mod, float, ⊇, ⊊, ⊋,
+             UnitRange
 
 export AbstractInterval, Interval, OpenInterval, ClosedInterval, @iv_str,
             ⊇, .., ±, ordered, width, leftendpoint, rightendpoint, endpoints,


### PR DESCRIPTION
Since a method is being added to `UnitRange` in this package, this needs to be imported explicitly.